### PR TITLE
feat: implement auto-scaling grid layout for TV presentation mode

### DIFF
--- a/mk-dashboard/CLAUDE.md
+++ b/mk-dashboard/CLAUDE.md
@@ -1,0 +1,177 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+MK Dashboard is a data visualization dashboard for Metropolia Krakowska (Kraków Metropolis), displaying demographic and statistical data for 15 municipalities (gminy) in the greater Kraków region. The dashboard presents various indicators across multiple thematic areas with interactive charts and modals.
+
+## Development Commands
+
+```bash
+# Install dependencies
+npm install
+
+# Start development server (runs on Vite's default port, typically http://localhost:5173)
+npm run dev
+
+# Build for production (TypeScript compilation + Vite build)
+npm run build
+
+# Lint the codebase
+npm run lint
+
+# Preview production build locally
+npm run preview
+```
+
+## Tech Stack
+
+- **React 19.1** with TypeScript
+- **React Router v7** for navigation
+- **Vite** for build tooling
+- **Recharts** for data visualization
+- **ESLint** with TypeScript ESLint configuration
+- No test framework configured
+
+## Architecture
+
+### Data Layer (`src/data/`)
+
+The application uses a static data architecture with no backend API:
+
+- **`bdl.ts`**: Core data module containing raw statistical data from Bank Danych Lokalnych (BDL)
+  - Defines 15 gminy (municipalities) and 6 years of data (2019-2024)
+  - Contains typed datasets: `powierzchniaKm2`, `gestosc`, `przyrostNaturalny`, `obciazenieDemograficzne`, `udzialWiekowych`
+  - All data is organized as `Record<Gmina, Record<Rok, number>>`
+
+- **`utils.ts`**: Data computation utilities
+  - `computeLudnosc(gmina, rok)`: Calculates population from density × area
+  - `computeMKSum()`: Aggregates values across all municipalities
+  - `weightedAverage()`: Computes population-weighted averages for indicators
+  - Exports pre-computed MK-wide aggregates like `MK_ludnosc`, `MK_gestosc`, `MK_obciazenie`
+
+- **`edukacja.ts`**: Contains education-specific datasets
+
+### Component Architecture
+
+**Reusable Components (`src/components/`)**:
+
+- **`Layout.tsx`**: App shell with header navigation, footer, and `<Outlet/>` for React Router
+  - Navigation uses client-side routing with `NavLink` for active states
+  - Fixed header/footer with scrollable content area
+
+- **`Card.tsx`**: Universal card container for dashboard widgets
+  - Props: `title`, `subtitle`, `right` (for custom right-side content), `height`, `onOpen` (for modal triggers)
+  - Used extensively across all dashboard pages
+
+- **`Modal.tsx`**: Full-screen modal overlay
+  - Supports ESC key to close
+  - Props: `open`, `onClose`, `title`, `width`, `maxWidth`
+  - Used to show enlarged versions of charts
+
+**Page Components (`src/pages/`)**:
+
+Each page represents a thematic section of the dashboard:
+- `InformacjeOgolne.tsx` - General information (landing page)
+- `InteligentneZarzadzanie.tsx` - Smart governance
+- `SrodowiskoPrzestrzen.tsx` - Environment & space
+- `Mobilnosc.tsx` - Mobility
+- `KulturaCzasuWolnego.tsx` - Culture & leisure
+- `Gospodarka.tsx` - Economy
+- `Edukacja.tsx` - Education
+- `UslugiSpoleczne.tsx` - Social services
+
+The `placeholder/` subdirectory contains earlier versions of some pages.
+
+### Typical Page Structure Pattern
+
+Pages follow a consistent pattern:
+
+```tsx
+export default function PageName() {
+  const [openCard, setOpenCard] = useState<string | null>(null);
+  const [scale, setScale] = useState(1);
+
+  return (
+    <div style={{ height: '100%', display: 'flex', flexDirection: 'column', overflow: 'hidden' }}>
+      <h2>Page Title</h2>
+
+      {/* Main content area with auto-scaling column layout */}
+      <div style={{ flex: 1, minHeight: 0, overflow: 'hidden', position: 'relative' }}>
+        <div style={{ position: 'absolute', inset: 0, ... }}>
+          <div style={{ columnCount: 3, columnGap: 12, transform: `scale(${scale})`, ... }}>
+            {/* Cards with charts/data */}
+            <div style={{ breakInside: 'avoid', marginBottom: 12 }}>
+              <Card title="..." onOpen={() => setOpenCard('cardId')}>
+                {/* Recharts chart or data display */}
+              </Card>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Modal for expanded view */}
+      <Modal open={openCard === 'cardId'} onClose={() => setOpenCard(null)} title="...">
+        {/* Larger version of the chart */}
+      </Modal>
+    </div>
+  );
+}
+```
+
+**Key architectural patterns**:
+- **Auto-scaling layout**: Pages use `transform: scale()` with ResizeObserver to dynamically fit content
+- **Column-based layout**: Most pages use CSS `columnCount: 3` with `breakInside: avoid` for masonry-style card arrangement
+- **Modal expansion**: Cards with `onOpen` prop can be clicked to open a modal with an enlarged view
+- **Static data**: All data is imported from `src/data/` modules at build time
+
+### Styling & Theming
+
+- **`theme.ts`**: Centralized theme configuration
+  - Brand colors: `mkColors.primaryRed`, `mkColors.primaryBurgundy`, `mkColors.primaryNavy`
+  - Reusable style objects: `appStyles.page`, `appStyles.kpiCard`, `appStyles.kpiGrid`, etc.
+  - Chart colors array for consistent Recharts styling
+
+- **`index.css`**: Global styles with CSS custom properties
+  - Uses CSS variables: `--mk-red`, `--mk-navy`, `--mk-bg`, `--mk-card`, etc.
+  - Defines `.card` base styles and `.masonry` / `.masonry-item` for responsive column layouts
+  - Responsive breakpoints for masonry: 3 columns (≥1024px), 2 columns (768-1023px), 1 column (<768px)
+
+### Routing (`src/App.tsx`)
+
+Single-level routing with all routes nested under `<Layout>`:
+- `/` → InformacjeOgolne (home page)
+- `/inteligentne-zarzadzanie` → InteligentneZarzadzanie
+- `/srodowisko-przestrzen` → SrodowiskoPrzestrzen
+- `/mobilnosc` → Mobilnosc
+- `/kultura-czasu-wolnego` → KulturaCzasuWolnego
+- `/gospodarka` → Gospodarka
+- `/edukacja` → Edukacja
+- `/uslugi-spoleczne` → UslugiSpoleczne
+
+## Code Conventions
+
+- TypeScript strict mode enabled
+- Use Polish language for UI text and data labels (the dashboard is for Polish users)
+- Import paths are relative (no path aliases configured)
+- Chart data is typically computed in `useMemo` hooks to avoid recalculation
+- Number formatting uses `Intl.NumberFormat('pl-PL')` for Polish locale
+- Components use inline styles (no CSS modules or styled-components)
+- Recharts configuration: Use `ResponsiveContainer` for all charts, set appropriate margins for axis labels
+
+## Data Patterns
+
+When working with BDL data:
+- Population is computed, not stored directly: use `computeLudnosc(gmina, rok)`
+- For MK-wide totals: use `computeMKSum()` for summable metrics, `weightedAverage()` for rates/ratios
+- Current year constant: `Y = 2024` (update annually)
+- Available years: `LATA = [2019, 2020, 2021, 2022, 2023, 2024]`
+- Gminy list: `GMINY` array (15 municipalities including Kraków)
+
+## Key Files
+
+- **Entry point**: `src/main.tsx`
+- **Root component**: `src/App.tsx`
+- **Page index**: `src/pages/index.ts` (barrel export for all pages)
+- **Type definitions**: `src/data/bdl.ts` (defines `Rok`, `Gmina` types)

--- a/mk-dashboard/src/components/Card.tsx
+++ b/mk-dashboard/src/components/Card.tsx
@@ -5,6 +5,7 @@ export default function Card({
   children,
   height,
   onOpen,
+  style,
 }: {
   title?: string;
   subtitle?: string;
@@ -12,9 +13,10 @@ export default function Card({
   children?: React.ReactNode;
   height?: number;
   onOpen?: () => void;
+  style?: React.CSSProperties;
 }) {
   return (
-    <div className="card" style={{ padding: 12, height }}>
+    <div className="card" style={{ padding: 12, height, ...style }}>
       {(title || subtitle || right) && (
         <div
           style={{

--- a/mk-dashboard/src/pages/Edukacja.tsx
+++ b/mk-dashboard/src/pages/Edukacja.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useRef, useEffect } from "react";
 import Card from "../components/Card";
 import Modal from "../components/Modal";
 import { GMINY } from "../data/bdl";
@@ -19,8 +19,32 @@ import {
 } from "recharts";
 
 export default function Edukacja() {
-  const [scale, setScale] = useState(1);
   const [openCard, setOpenCard] = useState<string | null>(null);
+  const [scale, setScale] = useState(1);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const contentRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    const content = contentRef.current;
+    if (!container || !content) return;
+
+    const observer = new ResizeObserver(() => {
+      const containerWidth = container.offsetWidth;
+      const containerHeight = container.offsetHeight;
+      const contentWidth = content.scrollWidth;
+      const contentHeight = content.scrollHeight;
+
+      const scaleX = containerWidth / contentWidth;
+      const scaleY = containerHeight / contentHeight;
+      const newScale = Math.min(scaleX, scaleY, 1);
+
+      setScale(newScale);
+    });
+
+    observer.observe(container);
+    return () => observer.disconnect();
+  }, []);
 
   return (
     <div
@@ -35,6 +59,7 @@ export default function Edukacja() {
         Edukacja
       </h2>
       <div
+        ref={containerRef}
         style={{
           flex: 1,
           minHeight: 0,
@@ -46,582 +71,326 @@ export default function Edukacja() {
           style={{
             position: "absolute",
             inset: 0,
-            overflow: "hidden",
             display: "flex",
-            justifyContent: "flex-start",
-            alignItems: "flex-start",
-            padding: "0 12px",
+            alignItems: "center",
+            justifyContent: "center",
           }}
         >
           <div
+            ref={contentRef}
             style={{
-              columnCount: 3,
-              columnGap: 12,
-              transformOrigin: "top left",
               transform: `scale(${scale})`,
-              width: "100%",
-              maxWidth: "100%",
-            }}
-            ref={(el) => {
-              if (el && el.parentElement?.parentElement) {
-                const container = el.parentElement.parentElement;
-                const updateScale = () => {
-                  const containerHeight = container.clientHeight;
-                  const containerWidth = container.clientWidth;
-
-                  el.style.transform = "scale(1)";
-                  const contentHeight = el.scrollHeight;
-                  const contentWidth = el.scrollWidth;
-                  el.style.transform = `scale(${scale})`;
-
-                  const heightScale = containerHeight / contentHeight;
-                  const widthScale = containerWidth / contentWidth;
-
-                  let newScale = Math.min(heightScale, widthScale, 1);
-                  newScale = Math.max(0.5, Math.min(1, newScale));
-
-                  setScale(newScale);
-                };
-
-                setTimeout(updateScale, 100);
-                setTimeout(updateScale, 500);
-
-                const resizeObserver = new ResizeObserver(() => {
-                  setTimeout(updateScale, 50);
-                });
-                resizeObserver.observe(container);
-
-                return () => resizeObserver.disconnect();
-              }
+              transformOrigin: "center center",
+              padding: "0 32px",
             }}
           >
-            <div style={{ breakInside: "avoid", marginBottom: 12 }}>
-              <Card
+            <div
+              style={{
+                display: "grid",
+                gridTemplateColumns: "repeat(3, 1fr)",
+                gap: 12,
+                maxWidth: "1800px",
+                margin: "0 auto",
+              }}
+            >
+        <div style={{ gridColumn: "span 2" }}>
+          <Card
+            title="Zadowolenie z jakości edukacji"
+            subtitle="Źródło: ArcGIS Experience"
+            height={420}
+          >
+            <div style={{ height: 360 }}>
+              <iframe
                 title="Zadowolenie z jakości edukacji"
-                subtitle="Źródło: ArcGIS Experience"
-                height={380}
-              >
-                <div style={{ height: 320 }}>
-                  <iframe
-                    title="Zadowolenie z jakości edukacji"
-                    src="https://experience.arcgis.com/experience/d174d0e98bae40039c667978707468ac/"
-                    style={{ width: "100%", height: "100%", border: 0 }}
-                    loading="lazy"
-                    allowFullScreen
-                  />
-                </div>
-              </Card>
+                src="https://experience.arcgis.com/experience/d174d0e98bae40039c667978707468ac/"
+                style={{ width: "100%", height: "100%", border: 0 }}
+                loading="lazy"
+                allowFullScreen
+              />
             </div>
+          </Card>
+        </div>
 
-            <div style={{ breakInside: "avoid", marginBottom: 12 }}>
-              <Card
-                title="Matury - matematyka"
-                subtitle="Źródło: CKE"
-                height={380}
-                onOpen={() => setOpenCard("matematyka")}
+        <Card
+          title="Środki na infrastrukturę oświaty"
+          subtitle="Źródło: zestawienie budżetowe"
+          height={380}
+          onOpen={() => setOpenCard("srodki")}
+        >
+          <div style={{ height: 320 }}>
+            <ResponsiveContainer width="100%" height="100%">
+              <BarChart
+                data={[
+                  { gmina: "Kraków", kwota: 54216533.0 },
+                  { gmina: "Liszki", kwota: 29044584.46 },
+                  { gmina: "Wieliczka", kwota: 19968529.4 },
+                  { gmina: "Wielka Wieś", kwota: 8097479.43 },
+                  { gmina: "Kocmyrzów-Luborzyca", kwota: 6763383.69 },
+                  { gmina: "Biskupice", kwota: 4722501.98 },
+                  { gmina: "Świątniki Górne", kwota: 4199803.71 },
+                  { gmina: "Czernichów", kwota: 2609291.14 },
+                  { gmina: "Skawina", kwota: 2342207.06 },
+                  { gmina: "Zielonki", kwota: 1355049.66 },
+                  { gmina: "Mogilany", kwota: 959757.23 },
+                  { gmina: "Niepołomice", kwota: 683352.27 },
+                  { gmina: "Michałowice", kwota: 418611.82 },
+                  { gmina: "Igołomia-Wawrzeńczyce", kwota: 114309.33 },
+                  { gmina: "Zabierzów", kwota: 3070.54 },
+                ]
+                  .slice()
+                  .sort((a, b) => b.kwota - a.kwota)}
+                margin={{ top: 8, right: 8, bottom: 84, left: 8 }}
               >
-                <div style={{ height: 320 }}>
-                  <ResponsiveContainer width="100%" height="100%">
-                    <BarChart
-                      data={[
-                        { gmina: "Kraków", wynik: 70.71 },
-                        { gmina: "Zielonki", wynik: 69.85 },
-                        { gmina: "Wielka Wieś", wynik: 68.1 },
-                        { gmina: "Zabierzów", wynik: 67.77 },
-                        { gmina: "Świątniki Górne", wynik: 67.78 },
-                        { gmina: "Biskupice", wynik: 67.1 },
-                        { gmina: "Mogilany", wynik: 66.9 },
-                        { gmina: "Wieliczka", wynik: 65.44 },
-                        { gmina: "Czernichów", wynik: 63.7 },
-                        { gmina: "Liszki", wynik: 62.58 },
-                        { gmina: "Kocmyrzów-Luborzyca", wynik: 60.19 },
-                        { gmina: "Skawina", wynik: 59.14 },
-                        { gmina: "Michałowice", wynik: 58.7 },
-                        { gmina: "Igołomia-Wawrzeńczyce", wynik: 57.31 },
-                        { gmina: "Niepołomice", wynik: 55.35 },
-                      ]
-                        .slice()
-                        .sort((a, b) => b.wynik - a.wynik)}
-                      margin={{ top: 8, right: 8, bottom: 84, left: 8 }}
-                    >
-                      <CartesianGrid vertical={false} stroke="#eee" />
-                      <XAxis
-                        dataKey="gmina"
-                        angle={-35}
-                        textAnchor="end"
-                        interval={0}
-                        height={60}
-                        tick={{ fontSize: 11 }}
-                      />
-                      <YAxis unit="%" tick={{ fontSize: 11 }} />
-                      <Tooltip
-                        formatter={(v: number) => [`${v}%`, "średni wynik"]}
-                        labelStyle={{ fontSize: 11 }}
-                        itemStyle={{ fontSize: 11 }}
-                      />
-                      <Bar
-                        dataKey="wynik"
-                        name="Matury matematyka [%]"
-                        fill="rgb(197, 59, 0)"
-                        label={{ position: "top", fontSize: 10, fill: "#333" }}
-                      />
-                    </BarChart>
-                  </ResponsiveContainer>
-                </div>
-              </Card>
-            </div>
+                <CartesianGrid vertical={false} stroke="#eee" />
+                <XAxis
+                  dataKey="gmina"
+                  angle={-35}
+                  textAnchor="end"
+                  interval={0}
+                  height={60}
+                  tick={{ fontSize: 11 }}
+                />
+                <YAxis
+                  tickFormatter={(value) =>
+                    new Intl.NumberFormat("pl-PL", {
+                      notation: "compact",
+                      minimumFractionDigits: 0,
+                      maximumFractionDigits: 1,
+                    }).format(value)
+                  }
+                  tick={{ fontSize: 11 }}
+                />
+                <Tooltip
+                  formatter={(v: number) => [
+                    new Intl.NumberFormat("pl-PL").format(v),
+                    "środki [zł]",
+                  ]}
+                  labelStyle={{ fontSize: 11 }}
+                  itemStyle={{ fontSize: 11 }}
+                />
+                <Bar
+                  dataKey="kwota"
+                  name="Środki [zł]"
+                  fill="rgb(197, 59, 0)"
+                  label={{
+                    position: "top",
+                    fontSize: 10,
+                    fill: "#333",
+                    formatter: (
+                      label: React.ReactNode
+                    ): React.ReactNode => {
+                      const value = Number(label);
+                      return `${(value / 1_000_000).toFixed(1)}M`;
+                    },
+                  }}
+                />
+              </BarChart>
+            </ResponsiveContainer>
+          </div>
+        </Card>
 
-            <div style={{ breakInside: "avoid", marginBottom: 12 }}>
-              <Card
-                title="Matury - język polski"
-                subtitle="Źródło: CKE"
-                height={380}
-                onOpen={() => setOpenCard("polski")}
+        <Card
+          title="Dzieci przedszkolne 3–5 lat (2019–2024)"
+          subtitle="Źródło: BDL GUS"
+          height={340}
+          onOpen={() => setOpenCard("dzieci")}
+        >
+          <div style={{ height: 280 }}>
+            <ResponsiveContainer width="100%" height="100%">
+              <BarChart
+                data={LATA.map((rok) => ({
+                  rok: String(rok),
+                  liczba: GMINY.reduce(
+                    (sum, g) =>
+                      sum + (dzieciPrzedszkolne3_5Lat[g][rok] || 0),
+                    0
+                  ),
+                }))}
+                margin={{ top: 24, right: 8, bottom: 16, left: 8 }}
               >
-                <div style={{ height: 320 }}>
-                  <ResponsiveContainer width="100%" height="100%">
-                    <BarChart
-                      data={[
-                        { gmina: "Kraków", wynik: 74.21 },
-                        { gmina: "Kocmyrzów-Luborzyca", wynik: 73.5 },
-                        { gmina: "Zielonki", wynik: 72.85 },
-                        { gmina: "Czernichów", wynik: 70.92 },
-                        { gmina: "Świątniki Górne", wynik: 69.93 },
-                        { gmina: "Mogilany", wynik: 69.99 },
-                        { gmina: "Wielka Wieś", wynik: 69.04 },
-                        { gmina: "Liszki", wynik: 68.11 },
-                        { gmina: "Biskupice", wynik: 67.31 },
-                        { gmina: "Wieliczka", wynik: 67.31 },
-                        { gmina: "Zabierzów", wynik: 66.47 },
-                        { gmina: "Igołomia-Wawrzeńczyce", wynik: 63.83 },
-                        { gmina: "Skawina", wynik: 63.09 },
-                        { gmina: "Niepołomice", wynik: 61.15 },
-                        { gmina: "Michałowice", wynik: 60.82 },
-                      ]
-                        .slice()
-                        .sort((a, b) => b.wynik - a.wynik)}
-                      margin={{ top: 8, right: 8, bottom: 84, left: 8 }}
-                    >
-                      <CartesianGrid vertical={false} stroke="#eee" />
-                      <XAxis
-                        dataKey="gmina"
-                        angle={-35}
-                        textAnchor="end"
-                        interval={0}
-                        height={60}
-                        tick={{ fontSize: 11 }}
-                      />
-                      <YAxis unit="%" tick={{ fontSize: 11 }} />
-                      <Tooltip
-                        formatter={(v: number) => [`${v}%`, "średni wynik"]}
-                        labelStyle={{ fontSize: 11 }}
-                        itemStyle={{ fontSize: 11 }}
-                      />
-                      <Bar
-                        dataKey="wynik"
-                        name="Matury polski [%]"
-                        fill="rgb(244, 76, 0)"
-                        label={{ position: "top", fontSize: 10, fill: "#333" }}
-                      />
-                    </BarChart>
-                  </ResponsiveContainer>
-                </div>
-              </Card>
-            </div>
+                <CartesianGrid vertical={false} stroke="#eee" />
+                <XAxis dataKey="rok" tick={{ fontSize: 11 }} />
+                <YAxis
+                  domain={["dataMin - 5000", "dataMax + 5000"]}
+                  tick={{ fontSize: 11 }}
+                />
+                <Tooltip
+                  formatter={(v: number) => [
+                    new Intl.NumberFormat("pl-PL").format(v),
+                    "dzieci 3–5 lat",
+                  ]}
+                  labelStyle={{ fontSize: 11 }}
+                  itemStyle={{ fontSize: 11 }}
+                />
+                <Bar
+                  dataKey="liczba"
+                  name="Dzieci 3–5 lat"
+                  fill="rgb(197, 59, 0)"
+                  label={{
+                    position: "top",
+                    fontSize: 10,
+                    fill: "#333",
+                    formatter: (v: React.ReactNode): React.ReactNode => {
+                      if (typeof v === "number") {
+                        return new Intl.NumberFormat("pl-PL").format(v);
+                      }
+                      return v;
+                    },
+                  }}
+                />
+              </BarChart>
+            </ResponsiveContainer>
+          </div>
+        </Card>
 
-            <div style={{ breakInside: "avoid", marginBottom: 12 }}>
-              <Card
-                title="Środki na infrastrukturę oświaty"
-                subtitle="Źródło: zestawienie budżetowe"
-                height={380}
-                onOpen={() => setOpenCard("srodki")}
+        <Card
+          title="Szkoły podstawowe"
+          subtitle="Źródło: RSiPO"
+          height={380}
+          onOpen={() => setOpenCard("szkoly")}
+        >
+          <div style={{ height: 320 }}>
+            <ResponsiveContainer width="100%" height="100%">
+              <BarChart
+                data={[
+                  { gmina: "Kraków-Podgórze", liczba: 75 },
+                  { gmina: "Kraków-Krowodrza", liczba: 47 },
+                  { gmina: "Kraków-Śródmieście", liczba: 43 },
+                  { gmina: "Kraków-Nowa Huta", liczba: 41 },
+                  { gmina: "Wieliczka", liczba: 29 },
+                  { gmina: "Skawina", liczba: 21 },
+                  { gmina: "Zabierzów", liczba: 12 },
+                  { gmina: "Niepołomice", liczba: 12 },
+                  { gmina: "Liszki", liczba: 11 },
+                  { gmina: "Czernichów", liczba: 9 },
+                  { gmina: "Kocmyrzów-Luborzyca", liczba: 9 },
+                  { gmina: "Mogilany", liczba: 7 },
+                  { gmina: "Biskupice", liczba: 6 },
+                  { gmina: "Słomniki", liczba: 6 },
+                  { gmina: "Wielka Wieś", liczba: 6 },
+                  { gmina: "Zielonki", liczba: 6 },
+                  { gmina: "Świątniki Górne", liczba: 6 },
+                  { gmina: "Igołomia-Wawrzeńczyce", liczba: 4 },
+                  { gmina: "Michałowice", liczba: 3 },
+                ].sort((a, b) => b.liczba - a.liczba)}
+                margin={{ top: 8, right: 8, bottom: 84, left: 8 }}
               >
-                <div style={{ height: 320 }}>
-                  <ResponsiveContainer width="100%" height="100%">
-                    <BarChart
-                      data={[
-                        { gmina: "Kraków", kwota: 54216533.0 },
-                        { gmina: "Liszki", kwota: 29044584.46 },
-                        { gmina: "Wieliczka", kwota: 19968529.4 },
-                        { gmina: "Wielka Wieś", kwota: 8097479.43 },
-                        { gmina: "Kocmyrzów-Luborzyca", kwota: 6763383.69 },
-                        { gmina: "Biskupice", kwota: 4722501.98 },
-                        { gmina: "Świątniki Górne", kwota: 4199803.71 },
-                        { gmina: "Czernichów", kwota: 2609291.14 },
-                        { gmina: "Skawina", kwota: 2342207.06 },
-                        { gmina: "Zielonki", kwota: 1355049.66 },
-                        { gmina: "Mogilany", kwota: 959757.23 },
-                        { gmina: "Niepołomice", kwota: 683352.27 },
-                        { gmina: "Michałowice", kwota: 418611.82 },
-                        { gmina: "Igołomia-Wawrzeńczyce", kwota: 114309.33 },
-                        { gmina: "Zabierzów", kwota: 3070.54 },
-                      ]
-                        .slice()
-                        .sort((a, b) => b.kwota - a.kwota)}
-                      margin={{ top: 8, right: 8, bottom: 84, left: 8 }}
-                    >
-                      <CartesianGrid vertical={false} stroke="#eee" />
-                      <XAxis
-                        dataKey="gmina"
-                        angle={-35}
-                        textAnchor="end"
-                        interval={0}
-                        height={60}
-                        tick={{ fontSize: 11 }}
-                      />
-                      <YAxis
-                        tickFormatter={(value) =>
-                          new Intl.NumberFormat("pl-PL", {
-                            notation: "compact",
-                            minimumFractionDigits: 0,
-                            maximumFractionDigits: 1,
-                          }).format(value)
-                        }
-                        tick={{ fontSize: 11 }}
-                      />
-                      <Tooltip
-                        formatter={(v: number) => [
-                          new Intl.NumberFormat("pl-PL").format(v),
-                          "środki [zł]",
-                        ]}
-                        labelStyle={{ fontSize: 11 }}
-                        itemStyle={{ fontSize: 11 }}
-                      />
-                      <Bar
-                        dataKey="kwota"
-                        name="Środki [zł]"
-                        fill="rgb(197, 59, 0)"
-                        label={{
-                          position: "top",
-                          fontSize: 10,
-                          fill: "#333",
-                          formatter: (
-                            label: React.ReactNode
-                          ): React.ReactNode => {
-                            const value = Number(label);
-                            return `${(value / 1_000_000).toFixed(1)}M`;
-                          },
-                        }}
-                      />
-                    </BarChart>
-                  </ResponsiveContainer>
-                </div>
-              </Card>
-            </div>
+                <CartesianGrid vertical={false} stroke="#eee" />
+                <XAxis
+                  dataKey="gmina"
+                  angle={-35}
+                  textAnchor="end"
+                  interval={0}
+                  height={60}
+                  tick={{ fontSize: 11 }}
+                />
+                <YAxis tick={{ fontSize: 11 }} />
+                <Tooltip
+                  formatter={(v: number) => [
+                    String(v),
+                    "szkoły podstawowe",
+                  ]}
+                  labelStyle={{ fontSize: 11 }}
+                  itemStyle={{ fontSize: 11 }}
+                />
+                <Bar
+                  dataKey="liczba"
+                  name="Szkoły podstawowe"
+                  fill="rgb(244, 76, 0)"
+                  label={{ position: "top", fontSize: 10, fill: "#333" }}
+                />
+              </BarChart>
+            </ResponsiveContainer>
+          </div>
+        </Card>
 
-            <div style={{ breakInside: "avoid", marginBottom: 12 }}>
-              <Card
-                title="Dzieci przedszkolne 3–5 lat (2019–2024)"
-                subtitle="Źródło: BDL GUS"
-                height={340}
-                onOpen={() => setOpenCard("dzieci")}
+        <Card
+          title="Egzamin 8-klasisty - polski"
+          subtitle="Źródło: OKE Kraków"
+          height={380}
+          onOpen={() => setOpenCard("egzaminPolski")}
+        >
+          <div style={{ height: 320 }}>
+            <ResponsiveContainer width="100%" height="100%">
+              <BarChart
+                data={GMINY.map((gmina) => ({
+                  gmina,
+                  wynik: wynikiOsmoklasPolski2024[gmina],
+                })).sort((a, b) => b.wynik - a.wynik)}
+                margin={{ top: 8, right: 8, bottom: 84, left: 8 }}
               >
-                <div style={{ height: 280 }}>
-                  <ResponsiveContainer width="100%" height="100%">
-                    <BarChart
-                      data={LATA.map((rok) => ({
-                        rok: String(rok),
-                        liczba: GMINY.reduce(
-                          (sum, g) =>
-                            sum + (dzieciPrzedszkolne3_5Lat[g][rok] || 0),
-                          0
-                        ),
-                      }))}
-                      margin={{ top: 24, right: 8, bottom: 16, left: 8 }}
-                    >
-                      <CartesianGrid vertical={false} stroke="#eee" />
-                      <XAxis dataKey="rok" tick={{ fontSize: 11 }} />
-                      <YAxis
-                        domain={["dataMin - 5000", "dataMax + 5000"]}
-                        tick={{ fontSize: 11 }}
-                      />
-                      <Tooltip
-                        formatter={(v: number) => [
-                          new Intl.NumberFormat("pl-PL").format(v),
-                          "dzieci 3–5 lat",
-                        ]}
-                        labelStyle={{ fontSize: 11 }}
-                        itemStyle={{ fontSize: 11 }}
-                      />
-                      <Bar
-                        dataKey="liczba"
-                        name="Dzieci 3–5 lat"
-                        fill="rgb(197, 59, 0)"
-                        label={{
-                          position: "top",
-                          fontSize: 10,
-                          fill: "#333",
-                          formatter: (v: React.ReactNode): React.ReactNode => {
-                            if (typeof v === "number") {
-                              return new Intl.NumberFormat("pl-PL").format(v);
-                            }
-                            return v;
-                          },
-                        }}
-                      />
-                    </BarChart>
-                  </ResponsiveContainer>
-                </div>
-              </Card>
-            </div>
+                <CartesianGrid vertical={false} stroke="#eee" />
+                <XAxis
+                  dataKey="gmina"
+                  angle={-35}
+                  textAnchor="end"
+                  interval={0}
+                  height={60}
+                  tick={{ fontSize: 11 }}
+                />
+                <YAxis unit=" %" tick={{ fontSize: 11 }} />
+                <Tooltip
+                  formatter={(v: number) => [`${v}%`, "średni wynik"]}
+                  labelStyle={{ fontSize: 11 }}
+                  itemStyle={{ fontSize: 11 }}
+                />
+                <Bar
+                  dataKey="wynik"
+                  name="Wynik polski [%]"
+                  fill="rgb(197, 59, 0)"
+                  label={{ position: "top", fontSize: 10, fill: "#333" }}
+                />
+              </BarChart>
+            </ResponsiveContainer>
+          </div>
+        </Card>
 
-            <div style={{ breakInside: "avoid", marginBottom: 12 }}>
-              <Card
-                title="Szkoły podstawowe"
-                subtitle="Źródło: RSiPO"
-                height={380}
-                onOpen={() => setOpenCard("szkoly")}
+        <Card
+          title="Egzamin 8-klasisty - matematyka"
+          subtitle="Źródło: OKE Kraków"
+          height={380}
+          onOpen={() => setOpenCard("egzaminMatematyka")}
+        >
+          <div style={{ height: 320 }}>
+            <ResponsiveContainer width="100%" height="100%">
+              <BarChart
+                data={GMINY.map((gmina) => ({
+                  gmina,
+                  wynik: wynikiOsmoklasMatematyka2024[gmina],
+                })).sort((a, b) => b.wynik - a.wynik)}
+                margin={{ top: 8, right: 8, bottom: 84, left: 8 }}
               >
-                <div style={{ height: 320 }}>
-                  <ResponsiveContainer width="100%" height="100%">
-                    <BarChart
-                      data={[
-                        { gmina: "Kraków-Podgórze", liczba: 75 },
-                        { gmina: "Kraków-Krowodrza", liczba: 47 },
-                        { gmina: "Kraków-Śródmieście", liczba: 43 },
-                        { gmina: "Kraków-Nowa Huta", liczba: 41 },
-                        { gmina: "Wieliczka", liczba: 29 },
-                        { gmina: "Skawina", liczba: 21 },
-                        { gmina: "Zabierzów", liczba: 12 },
-                        { gmina: "Niepołomice", liczba: 12 },
-                        { gmina: "Liszki", liczba: 11 },
-                        { gmina: "Czernichów", liczba: 9 },
-                        { gmina: "Kocmyrzów-Luborzyca", liczba: 9 },
-                        { gmina: "Mogilany", liczba: 7 },
-                        { gmina: "Biskupice", liczba: 6 },
-                        { gmina: "Słomniki", liczba: 6 },
-                        { gmina: "Wielka Wieś", liczba: 6 },
-                        { gmina: "Zielonki", liczba: 6 },
-                        { gmina: "Świątniki Górne", liczba: 6 },
-                        { gmina: "Igołomia-Wawrzeńczyce", liczba: 4 },
-                        { gmina: "Michałowice", liczba: 3 },
-                      ].sort((a, b) => b.liczba - a.liczba)}
-                      margin={{ top: 8, right: 8, bottom: 84, left: 8 }}
-                    >
-                      <CartesianGrid vertical={false} stroke="#eee" />
-                      <XAxis
-                        dataKey="gmina"
-                        angle={-35}
-                        textAnchor="end"
-                        interval={0}
-                        height={60}
-                        tick={{ fontSize: 11 }}
-                      />
-                      <YAxis tick={{ fontSize: 11 }} />
-                      <Tooltip
-                        formatter={(v: number) => [
-                          String(v),
-                          "szkoły podstawowe",
-                        ]}
-                        labelStyle={{ fontSize: 11 }}
-                        itemStyle={{ fontSize: 11 }}
-                      />
-                      <Bar
-                        dataKey="liczba"
-                        name="Szkoły podstawowe"
-                        fill="rgb(244, 76, 0)"
-                        label={{ position: "top", fontSize: 10, fill: "#333" }}
-                      />
-                    </BarChart>
-                  </ResponsiveContainer>
-                </div>
-              </Card>
-            </div>
-
-            <div style={{ breakInside: "avoid", marginBottom: 12 }}>
-              <Card
-                title="Egzamin 8-klasisty - polski"
-                subtitle="Źródło: OKE Kraków"
-                height={380}
-                onOpen={() => setOpenCard("egzaminPolski")}
-              >
-                <div style={{ height: 320 }}>
-                  <ResponsiveContainer width="100%" height="100%">
-                    <BarChart
-                      data={GMINY.map((gmina) => ({
-                        gmina,
-                        wynik: wynikiOsmoklasPolski2024[gmina],
-                      })).sort((a, b) => b.wynik - a.wynik)}
-                      margin={{ top: 8, right: 8, bottom: 84, left: 8 }}
-                    >
-                      <CartesianGrid vertical={false} stroke="#eee" />
-                      <XAxis
-                        dataKey="gmina"
-                        angle={-35}
-                        textAnchor="end"
-                        interval={0}
-                        height={60}
-                        tick={{ fontSize: 11 }}
-                      />
-                      <YAxis unit=" %" tick={{ fontSize: 11 }} />
-                      <Tooltip
-                        formatter={(v: number) => [`${v}%`, "średni wynik"]}
-                        labelStyle={{ fontSize: 11 }}
-                        itemStyle={{ fontSize: 11 }}
-                      />
-                      <Bar
-                        dataKey="wynik"
-                        name="Wynik polski [%]"
-                        fill="rgb(197, 59, 0)"
-                        label={{ position: "top", fontSize: 10, fill: "#333" }}
-                      />
-                    </BarChart>
-                  </ResponsiveContainer>
-                </div>
-              </Card>
-            </div>
-
-            <div style={{ breakInside: "avoid", marginBottom: 12 }}>
-              <Card
-                title="Egzamin 8-klasisty - matematyka"
-                subtitle="Źródło: OKE Kraków"
-                height={380}
-                onOpen={() => setOpenCard("egzaminMatematyka")}
-              >
-                <div style={{ height: 320 }}>
-                  <ResponsiveContainer width="100%" height="100%">
-                    <BarChart
-                      data={GMINY.map((gmina) => ({
-                        gmina,
-                        wynik: wynikiOsmoklasMatematyka2024[gmina],
-                      })).sort((a, b) => b.wynik - a.wynik)}
-                      margin={{ top: 8, right: 8, bottom: 84, left: 8 }}
-                    >
-                      <CartesianGrid vertical={false} stroke="#eee" />
-                      <XAxis
-                        dataKey="gmina"
-                        angle={-35}
-                        textAnchor="end"
-                        interval={0}
-                        height={60}
-                        tick={{ fontSize: 11 }}
-                      />
-                      <YAxis unit=" %" tick={{ fontSize: 11 }} />
-                      <Tooltip
-                        formatter={(v: number) => [`${v}%`, "średni wynik"]}
-                        labelStyle={{ fontSize: 11 }}
-                        itemStyle={{ fontSize: 11 }}
-                      />
-                      <Bar
-                        dataKey="wynik"
-                        name="Wynik matematyka [%]"
-                        fill="rgb(244, 76, 0)"
-                        label={{ position: "top", fontSize: 10, fill: "#333" }}
-                      />
-                    </BarChart>
-                  </ResponsiveContainer>
-                </div>
-              </Card>
+                <CartesianGrid vertical={false} stroke="#eee" />
+                <XAxis
+                  dataKey="gmina"
+                  angle={-35}
+                  textAnchor="end"
+                  interval={0}
+                  height={60}
+                  tick={{ fontSize: 11 }}
+                />
+                <YAxis unit=" %" tick={{ fontSize: 11 }} />
+                <Tooltip
+                  formatter={(v: number) => [`${v}%`, "średni wynik"]}
+                  labelStyle={{ fontSize: 11 }}
+                  itemStyle={{ fontSize: 11 }}
+                />
+                <Bar
+                  dataKey="wynik"
+                  name="Wynik matematyka [%]"
+                  fill="rgb(244, 76, 0)"
+                  label={{ position: "top", fontSize: 10, fill: "#333" }}
+                />
+              </BarChart>
+            </ResponsiveContainer>
+          </div>
+        </Card>
             </div>
           </div>
         </div>
       </div>
 
       {/* Modals */}
-      <Modal
-        open={openCard === "matematyka"}
-        onClose={() => setOpenCard(null)}
-        title="Matury - matematyka"
-        width={1100}
-        maxWidth="95vw"
-      >
-        <div style={{ height: 600 }}>
-          <ResponsiveContainer width="100%" height="100%">
-            <BarChart
-              data={[
-                { gmina: "Kraków", wynik: 70.71 },
-                { gmina: "Zielonki", wynik: 69.85 },
-                { gmina: "Wielka Wieś", wynik: 68.1 },
-                { gmina: "Zabierzów", wynik: 67.77 },
-                { gmina: "Świątniki Górne", wynik: 67.78 },
-                { gmina: "Biskupice", wynik: 67.1 },
-                { gmina: "Mogilany", wynik: 66.9 },
-                { gmina: "Wieliczka", wynik: 65.44 },
-                { gmina: "Czernichów", wynik: 63.7 },
-                { gmina: "Liszki", wynik: 62.58 },
-                { gmina: "Kocmyrzów-Luborzyca", wynik: 60.19 },
-                { gmina: "Skawina", wynik: 59.14 },
-                { gmina: "Michałowice", wynik: 58.7 },
-                { gmina: "Igołomia-Wawrzeńczyce", wynik: 57.31 },
-                { gmina: "Niepołomice", wynik: 55.35 },
-              ]
-                .slice()
-                .sort((a, b) => b.wynik - a.wynik)}
-              margin={{ top: 8, right: 8, bottom: 84, left: 8 }}
-            >
-              <CartesianGrid vertical={false} stroke="#eee" />
-              <XAxis
-                dataKey="gmina"
-                angle={-35}
-                textAnchor="end"
-                interval={0}
-                height={60}
-              />
-              <YAxis unit="%" />
-              <Tooltip formatter={(v: number) => [`${v}%`, "średni wynik"]} />
-              <Bar
-                dataKey="wynik"
-                name="Matury matematyka [%]"
-                fill="rgb(197, 59, 0)"
-                label={{ position: "top", fontSize: 10, fill: "#333" }}
-              />
-            </BarChart>
-          </ResponsiveContainer>
-        </div>
-      </Modal>
-
-      <Modal
-        open={openCard === "polski"}
-        onClose={() => setOpenCard(null)}
-        title="Matury - język polski"
-        width={1100}
-        maxWidth="95vw"
-      >
-        <div style={{ height: 600 }}>
-          <ResponsiveContainer width="100%" height="100%">
-            <BarChart
-              data={[
-                { gmina: "Kraków", wynik: 74.21 },
-                { gmina: "Kocmyrzów-Luborzyca", wynik: 73.5 },
-                { gmina: "Zielonki", wynik: 72.85 },
-                { gmina: "Czernichów", wynik: 70.92 },
-                { gmina: "Świątniki Górne", wynik: 69.93 },
-                { gmina: "Mogilany", wynik: 69.99 },
-                { gmina: "Wielka Wieś", wynik: 69.04 },
-                { gmina: "Liszki", wynik: 68.11 },
-                { gmina: "Biskupice", wynik: 67.31 },
-                { gmina: "Wieliczka", wynik: 67.31 },
-                { gmina: "Zabierzów", wynik: 66.47 },
-                { gmina: "Igołomia-Wawrzeńczyce", wynik: 63.83 },
-                { gmina: "Skawina", wynik: 63.09 },
-                { gmina: "Niepołomice", wynik: 61.15 },
-                { gmina: "Michałowice", wynik: 60.82 },
-              ]
-                .slice()
-                .sort((a, b) => b.wynik - a.wynik)}
-              margin={{ top: 8, right: 8, bottom: 84, left: 8 }}
-            >
-              <CartesianGrid vertical={false} stroke="#eee" />
-              <XAxis
-                dataKey="gmina"
-                angle={-35}
-                textAnchor="end"
-                interval={0}
-                height={60}
-              />
-              <YAxis unit="%" />
-              <Tooltip formatter={(v: number) => [`${v}%`, "średni wynik"]} />
-              <Bar
-                dataKey="wynik"
-                name="Matury polski [%]"
-                fill="rgb(244, 76, 0)"
-                label={{ position: "top", fontSize: 10, fill: "#333" }}
-              />
-            </BarChart>
-          </ResponsiveContainer>
-        </div>
-      </Modal>
-
       <Modal
         open={openCard === "srodki"}
         onClose={() => setOpenCard(null)}

--- a/mk-dashboard/src/pages/InformacjeOgolne.tsx
+++ b/mk-dashboard/src/pages/InformacjeOgolne.tsx
@@ -102,49 +102,36 @@ export default function InformacjeOgolne() {
             overflow: "hidden",
             display: "flex",
             justifyContent: "center",
-            alignItems: "flex-start",
+            padding: "0 32px",
           }}
         >
           <div
             style={{
-              columnCount: 3,
-              columnGap: 12,
               transformOrigin: "top center",
               transform: `scale(${scale})`,
               width: "100%",
+              maxWidth: "1800px",
             }}
             ref={(el) => {
               if (el && el.parentElement?.parentElement) {
                 const container = el.parentElement.parentElement;
                 const updateScale = () => {
                   const containerHeight = container.clientHeight;
-                  const containerWidth = container.clientWidth;
 
-                  // Reset scale temporarily to get true dimensions
                   el.style.transform = "scale(1)";
                   const contentHeight = el.scrollHeight;
-                  const contentWidth = el.scrollWidth;
                   el.style.transform = `scale(${scale})`;
 
-                  // Calculate scale based on both height and width
                   const heightScale = containerHeight / contentHeight;
-                  const widthScale = containerWidth / contentWidth;
-
-                  // Use the smaller scale to ensure everything fits
-                  let newScale = Math.min(heightScale, widthScale, 1);
-
-                  // Apply minimum scale of 0.5 (50%) for readability
-                  // and maximum of 1 (100%) to avoid upscaling
-                  newScale = Math.max(0.5, Math.min(1, newScale));
+                  let newScale = Math.min(heightScale, 1);
+                  newScale = Math.max(0.4, Math.min(1, newScale));
 
                   setScale(newScale);
                 };
 
-                // Initial calculation with delay to ensure content is rendered
                 setTimeout(updateScale, 100);
                 setTimeout(updateScale, 500);
 
-                // Update on resize
                 const resizeObserver = new ResizeObserver(() => {
                   setTimeout(updateScale, 50);
                 });
@@ -154,10 +141,18 @@ export default function InformacjeOgolne() {
               }
             }}
           >
-            <div style={{ breakInside: "avoid", marginBottom: 12 }}>
+            <div
+              style={{
+                display: "grid",
+                gridTemplateColumns: "repeat(3, 1fr)",
+                gap: 12,
+              }}
+            >
+            <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
               <Card
                 title="Ludność Metropolii"
                 onOpen={() => setOpenCard("popSummary")}
+                height={160}
               >
                 <div
                   style={{
@@ -172,157 +167,13 @@ export default function InformacjeOgolne() {
                   />
                 </div>
               </Card>
-            </div>
 
-            <div style={{ breakInside: "avoid", marginBottom: 12 }}>
-              <Card
-                title="Gęstość zaludnienia Metropolii Krakowskiej"
-                subtitle="Źródło: ArcGIS Experience"
-                height={320}
-                onOpen={() => setOpenCard("densityMap")}
-              >
-                <div style={{ height: 240 }}>
-                  <iframe
-                    title="ArcGIS Experience Map"
-                    src="https://experience.arcgis.com/experience/cccd4cb137164897b676c97eee0c393d"
-                    style={{ width: "100%", height: "100%", border: 0 }}
-                    loading="lazy"
-                    allowFullScreen
-                  />
-                </div>
-              </Card>
-            </div>
-
-            <div style={{ breakInside: "avoid", marginBottom: 12 }}>
-              <Card
-                title="Zmiany liczby ludności Metropolii Krakowskiej w latach 2019–2024"
-                height={340}
-                onOpen={() => setOpenCard("mkTrend")}
-              >
-                <div style={{ height: 280 }}>
-                  <ResponsiveContainer width="100%" height="100%">
-                    <LineChart
-                      data={useMemo(
-                        () =>
-                          LATA.map((y) => ({
-                            rok: String(y),
-                            ludnosc: MK_ludnosc[y],
-                          })),
-                        []
-                      )}
-                      margin={{ top: 8, right: 8, bottom: 16, left: 8 }}
-                    >
-                      <CartesianGrid vertical={false} stroke="#eee" />
-                      <XAxis dataKey="rok" tick={{ fontSize: 11 }} />
-                      <YAxis
-                        domain={["dataMin - 5000", "dataMax + 5000"]}
-                        tickFormatter={(value) =>
-                          new Intl.NumberFormat("pl-PL", {
-                            notation: "compact",
-                            minimumFractionDigits: 2,
-                            maximumFractionDigits: 2,
-                          }).format(value)
-                        }
-                        tick={{ fontSize: 11 }}
-                      />
-                      <Tooltip
-                        formatter={(v: number) => [
-                          new Intl.NumberFormat("pl-PL").format(v),
-                          "ludność",
-                        ]}
-                        labelStyle={{ fontSize: 11 }}
-                        itemStyle={{ fontSize: 11 }}
-                      />
-                      <Line
-                        type="monotone"
-                        dataKey="ludnosc"
-                        name="ludność"
-                        stroke={IO_CHART_COLORS[2]}
-                        strokeWidth={2}
-                        dot={{ r: 2 }}
-                      />
-                    </LineChart>
-                  </ResponsiveContainer>
-                </div>
-              </Card>
-            </div>
-
-            <div style={{ breakInside: "avoid", marginBottom: 12 }}>
-              <Card title="Ludność gmin" onOpen={() => setOpenCard("gminyPop")}>
-                <div style={{ maxHeight: 280, overflowY: "auto" }}>
-                  <div className="masonry">
-                    {gminaPopData.map(({ gmina, pop }) => (
-                      <div key={gmina} className="masonry-item">
-                        <NumberKPI label={gmina} value={pop} size="sm" />
-                      </div>
-                    ))}
-                  </div>
-                </div>
-              </Card>
-            </div>
-
-            <div style={{ breakInside: "avoid", marginBottom: 12 }}>
-              <Card
-                title="Wskaźnik obciążenia demograficznego"
-                subtitle="Gminy Metropolii Krakowskiej"
-                height={380}
-                onOpen={() => setOpenCard("obciazenie")}
-              >
-                <p
-                  style={{ margin: "0 0 6px", color: "#6b7280", fontSize: 11 }}
-                >
-                  Liczba osób w wieku nieprodukcyjnym (przed- i poprodukcyjnym)
-                  na 100 osób w wieku produkcyjnym.
-                </p>
-                <div style={{ height: 320 }}>
-                  <ResponsiveContainer width="100%" height="100%">
-                    <BarChart
-                      data={useMemo(
-                        () =>
-                          GMINY.map((g) => ({
-                            gmina: g,
-                            wsk: obciazenieDemograficzne[g][Y],
-                          })).sort((a, b) => b.wsk - a.wsk),
-                        []
-                      )}
-                      margin={{ top: 8, right: 8, bottom: 100, left: 8 }}
-                    >
-                      <CartesianGrid vertical={false} stroke="#eee" />
-                      <XAxis
-                        dataKey="gmina"
-                        angle={-35}
-                        textAnchor="end"
-                        interval={0}
-                        height={60}
-                        tick={{ fontSize: 11 }}
-                      />
-                      <YAxis unit="" tick={{ fontSize: 11 }} />
-                      <Tooltip
-                        formatter={(v: number) => [
-                          v.toFixed(1),
-                          "na 100 w wieku prod.",
-                        ]}
-                        labelStyle={{ fontSize: 11 }}
-                        itemStyle={{ fontSize: 11 }}
-                      />
-                      <Bar
-                        dataKey="wsk"
-                        name="Liczba osób w wieku nieprodukcyjnym na 100 osób w wieku produkcyjnym"
-                        fill={IO_CHART_COLORS[1]}
-                      />
-                    </BarChart>
-                  </ResponsiveContainer>
-                </div>
-              </Card>
-            </div>
-
-            <div style={{ breakInside: "avoid", marginBottom: 12 }}>
               <Card
                 title="Zmiana liczby ludności w gminach Stowarzyszenia Metropolii Krakowskiej [%] w latach 2019–2024"
-                height={380}
+                height={248}
                 onOpen={() => setOpenCard("zmianaGmin")}
               >
-                <div style={{ height: 320 }}>
+                <div style={{ height: 188 }}>
                   <ResponsiveContainer width="100%" height="100%">
                     <BarChart
                       data={useMemo(
@@ -338,7 +189,7 @@ export default function InformacjeOgolne() {
                           }).sort((a, b) => b.wzrost - a.wzrost),
                         []
                       )}
-                      margin={{ top: 8, right: 8, bottom: 84, left: 8 }}
+                      margin={{ top: 8, right: 8, bottom: 64, left: 8 }}
                     >
                       <CartesianGrid vertical={false} stroke="#eee" />
                       <XAxis
@@ -346,17 +197,17 @@ export default function InformacjeOgolne() {
                         angle={-35}
                         textAnchor="end"
                         interval={0}
-                        height={60}
-                        tick={{ fontSize: 11 }}
+                        height={50}
+                        tick={{ fontSize: 9 }}
                       />
-                      <YAxis unit="%" tick={{ fontSize: 11 }} />
+                      <YAxis unit="%" tick={{ fontSize: 10 }} />
                       <Tooltip
                         formatter={(v: number) => [
                           `${v.toFixed(1)}%`,
                           "zmiana 2019–2024",
                         ]}
-                        labelStyle={{ fontSize: 11 }}
-                        itemStyle={{ fontSize: 11 }}
+                        labelStyle={{ fontSize: 10 }}
+                        itemStyle={{ fontSize: 10 }}
                       />
                       <Bar
                         dataKey="wzrost"
@@ -369,52 +220,187 @@ export default function InformacjeOgolne() {
               </Card>
             </div>
 
-            <div style={{ breakInside: "avoid", marginBottom: 12 }}>
+            <div style={{ display: "flex", flexDirection: "column", gap: 12, gridColumn: "span 2" }}>
               <Card
-                title="Zmiany liczby ludności w gminach Metropolii Krakowskiej w 2024 roku"
-                height={380}
-                onOpen={() => setOpenCard("przyrost2024")}
+                title="Gęstość zaludnienia Metropolii Krakowskiej"
+                subtitle="Źródło: ArcGIS Experience"
+                height={280}
+                onOpen={() => setOpenCard("densityMap")}
               >
-                <div style={{ height: 320 }}>
+                <div style={{ height: 200 }}>
+                  <iframe
+                    title="ArcGIS Experience Map"
+                    src="https://experience.arcgis.com/experience/cccd4cb137164897b676c97eee0c393d"
+                    style={{ width: "100%", height: "100%", border: 0 }}
+                    loading="lazy"
+                    allowFullScreen
+                  />
+                </div>
+              </Card>
+
+              <Card
+                title="Zmiany liczby ludności Metropolii Krakowskiej w latach 2019–2024"
+                height={128}
+                onOpen={() => setOpenCard("mkTrend")}
+              >
+                <div style={{ height: 68 }}>
                   <ResponsiveContainer width="100%" height="100%">
-                    <BarChart
+                    <LineChart
                       data={useMemo(
                         () =>
-                          GMINY.map((g: Gmina) => ({
-                            gmina: g,
-                            pn: przyrostNaturalny[g][Y],
-                          })).sort((a, b) => b.pn - a.pn),
+                          LATA.map((y) => ({
+                            rok: String(y),
+                            ludnosc: MK_ludnosc[y],
+                          })),
                         []
                       )}
-                      margin={{ top: 8, right: 8, bottom: 84, left: 8 }}
+                      margin={{ top: 4, right: 8, bottom: 4, left: 8 }}
                     >
                       <CartesianGrid vertical={false} stroke="#eee" />
-                      <XAxis
-                        dataKey="gmina"
-                        angle={-35}
-                        textAnchor="end"
-                        interval={0}
-                        height={60}
-                        tick={{ fontSize: 11 }}
+                      <XAxis dataKey="rok" tick={{ fontSize: 9 }} />
+                      <YAxis
+                        domain={["dataMin - 5000", "dataMax + 5000"]}
+                        tickFormatter={(value) =>
+                          new Intl.NumberFormat("pl-PL", {
+                            notation: "compact",
+                            minimumFractionDigits: 0,
+                            maximumFractionDigits: 0,
+                          }).format(value)
+                        }
+                        tick={{ fontSize: 9 }}
                       />
-                      <YAxis tick={{ fontSize: 11 }} />
                       <Tooltip
                         formatter={(v: number) => [
-                          `${v}`,
-                          "osób (przyrost naturalny)",
+                          new Intl.NumberFormat("pl-PL").format(v),
+                          "ludność",
                         ]}
-                        labelStyle={{ fontSize: 11 }}
-                        itemStyle={{ fontSize: 11 }}
+                        labelStyle={{ fontSize: 10 }}
+                        itemStyle={{ fontSize: 10 }}
                       />
-                      <Bar
-                        dataKey="pn"
-                        name="przyrost naturalny (osoby)"
-                        fill={IO_CHART_COLORS[0]}
+                      <Line
+                        type="monotone"
+                        dataKey="ludnosc"
+                        name="ludność"
+                        stroke={IO_CHART_COLORS[2]}
+                        strokeWidth={2}
+                        dot={{ r: 2 }}
                       />
-                    </BarChart>
+                    </LineChart>
                   </ResponsiveContainer>
                 </div>
               </Card>
+            </div>
+
+            <Card title="Ludność gmin" onOpen={() => setOpenCard("gminyPop")}>
+              <div style={{ padding: "8px 0" }}>
+                <div className="masonry">
+                  {gminaPopData.map(({ gmina, pop }) => (
+                    <div key={gmina} className="masonry-item">
+                      <NumberKPI label={gmina} value={pop} size="sm" />
+                    </div>
+                  ))}
+                </div>
+              </div>
+            </Card>
+
+            <Card
+              title="Zmiany liczby ludności w gminach Metropolii Krakowskiej w 2024 roku"
+              height={420}
+              onOpen={() => setOpenCard("przyrost2024")}
+              style={{ gridColumn: "span 2" }}
+            >
+              <div style={{ height: 360 }}>
+                <ResponsiveContainer width="100%" height="100%">
+                  <BarChart
+                    data={useMemo(
+                      () =>
+                        GMINY.map((g: Gmina) => ({
+                          gmina: g,
+                          pn: przyrostNaturalny[g][Y],
+                        })).sort((a, b) => b.pn - a.pn),
+                      []
+                    )}
+                    margin={{ top: 8, right: 8, bottom: 84, left: 8 }}
+                  >
+                    <CartesianGrid vertical={false} stroke="#eee" />
+                    <XAxis
+                      dataKey="gmina"
+                      angle={-35}
+                      textAnchor="end"
+                      interval={0}
+                      height={60}
+                      tick={{ fontSize: 11 }}
+                    />
+                    <YAxis tick={{ fontSize: 11 }} />
+                    <Tooltip
+                      formatter={(v: number) => [
+                        `${v}`,
+                        "osób (przyrost naturalny)",
+                      ]}
+                      labelStyle={{ fontSize: 11 }}
+                      itemStyle={{ fontSize: 11 }}
+                    />
+                    <Bar
+                      dataKey="pn"
+                      name="przyrost naturalny (osoby)"
+                      fill={IO_CHART_COLORS[0]}
+                    />
+                  </BarChart>
+                </ResponsiveContainer>
+              </div>
+            </Card>
+            <Card
+              title="Wskaźnik obciążenia demograficznego"
+              subtitle="Gminy Metropolii Krakowskiej"
+              height={300}
+              onOpen={() => setOpenCard("obciazenie")}
+            >
+              <p
+                style={{ margin: "0 0 6px", color: "#6b7280", fontSize: 11 }}
+              >
+                Liczba osób w wieku nieprodukcyjnym (przed- i poprodukcyjnym)
+                na 100 osób w wieku produkcyjnym.
+              </p>
+              <div style={{ height: 240 }}>
+                <ResponsiveContainer width="100%" height="100%">
+                  <BarChart
+                    data={useMemo(
+                      () =>
+                        GMINY.map((g) => ({
+                          gmina: g,
+                          wsk: obciazenieDemograficzne[g][Y],
+                        })).sort((a, b) => b.wsk - a.wsk),
+                      []
+                    )}
+                    margin={{ top: 8, right: 8, bottom: 84, left: 8 }}
+                  >
+                    <CartesianGrid vertical={false} stroke="#eee" />
+                    <XAxis
+                      dataKey="gmina"
+                      angle={-35}
+                      textAnchor="end"
+                      interval={0}
+                      height={60}
+                      tick={{ fontSize: 11 }}
+                    />
+                    <YAxis unit="" tick={{ fontSize: 11 }} />
+                    <Tooltip
+                      formatter={(v: number) => [
+                        v.toFixed(1),
+                        "na 100 w wieku prod.",
+                      ]}
+                      labelStyle={{ fontSize: 11 }}
+                      itemStyle={{ fontSize: 11 }}
+                    />
+                    <Bar
+                      dataKey="wsk"
+                      name="Liczba osób w wieku nieprodukcyjnym na 100 osób w wieku produkcyjnym"
+                      fill={IO_CHART_COLORS[1]}
+                    />
+                  </BarChart>
+                </ResponsiveContainer>
+              </div>
+            </Card>
             </div>
           </div>
         </div>

--- a/mk-dashboard/src/pages/InteligentneZarzadzanie.tsx
+++ b/mk-dashboard/src/pages/InteligentneZarzadzanie.tsx
@@ -12,8 +12,8 @@ import {
 } from "recharts";
 
 export default function InteligentneZarzadzanie() {
-  const [scale, setScale] = useState(1);
   const [openCard, setOpenCard] = useState<string | null>(null);
+  const [scale, setScale] = useState(1);
 
   return (
     <div
@@ -27,317 +27,276 @@ export default function InteligentneZarzadzanie() {
       <h2 style={{ margin: "2px 0 6px", flexShrink: 0, fontSize: "20px" }}>
         Inteligentne zarządzanie
       </h2>
-      <div
-        style={{
-          flex: 1,
-          minHeight: 0,
-          overflow: "hidden",
-          position: "relative",
-        }}
-      >
-        <div
-          style={{
-            position: "absolute",
-            inset: 0,
-            overflow: "hidden",
-            display: "flex",
-            justifyContent: "center",
-            alignItems: "flex-start",
-          }}
-        >
+      <div style={{ flex: 1, minHeight: 0, overflow: "hidden", position: "relative" }}>
+        <div style={{ position: "absolute", inset: 0, overflow: "hidden", display: "flex", justifyContent: "center", padding: "0 32px" }}>
           <div
-            style={{
-              columnCount: 3,
-              columnGap: 12,
-              transformOrigin: "top center",
-              transform: `scale(${scale})`,
-              width: "100%",
-            }}
+            style={{ transformOrigin: "top center", transform: `scale(${scale})`, width: "100%", maxWidth: "1800px" }}
             ref={(el) => {
               if (el && el.parentElement?.parentElement) {
                 const container = el.parentElement.parentElement;
                 const updateScale = () => {
                   const containerHeight = container.clientHeight;
-                  const containerWidth = container.clientWidth;
-
-                  // Reset scale temporarily to get true dimensions
                   el.style.transform = "scale(1)";
                   const contentHeight = el.scrollHeight;
-                  const contentWidth = el.scrollWidth;
                   el.style.transform = `scale(${scale})`;
-
-                  // Calculate scale based on both height and width
                   const heightScale = containerHeight / contentHeight;
-                  const widthScale = containerWidth / contentWidth;
-
-                  // Use the smaller scale to ensure everything fits
-                  let newScale = Math.min(heightScale, widthScale, 1);
-
-                  // Apply minimum scale of 0.5 (50%) for readability
-                  newScale = Math.max(0.5, Math.min(1, newScale));
-
+                  let newScale = Math.min(heightScale, 1);
+                  newScale = Math.max(0.4, Math.min(1, newScale));
                   setScale(newScale);
                 };
-
-                // Initial calculation with delay
                 setTimeout(updateScale, 100);
                 setTimeout(updateScale, 500);
-
-                // Update on resize
                 const resizeObserver = new ResizeObserver(() => {
                   setTimeout(updateScale, 50);
                 });
                 resizeObserver.observe(container);
-
                 return () => resizeObserver.disconnect();
               }
             }}
           >
-            <div style={{ breakInside: "avoid", marginBottom: 12 }}>
+            <div style={{ display: "grid", gridTemplateColumns: "repeat(3, 1fr)", gap: 12 }}>
               <Card
-                title="Poziom zadowolenia mieszkańców"
-                subtitle="Źródło: ArcGIS Experience"
-                height={380}
-                onOpen={() => setOpenCard("zadowolenie")}
-              >
-                <div style={{ height: 320 }}>
-                  <iframe
-                    title="Poziom zadowolenia mieszkańców"
-                    src="https://experience.arcgis.com/experience/51fd6fd2e6514e5ea7b17d5a60163f14/"
-                    style={{ width: "100%", height: "100%", border: 0 }}
-                    loading="lazy"
-                    allowFullScreen
-                  />
-                </div>
-              </Card>
-            </div>
+              title="Poziom zadowolenia mieszkańców z jakości funkcjonowania administracji w gminie"
+              subtitle="Źródło: Raport z badań społecznych 2024"
+              height={420}
+              onOpen={() => setOpenCard("zadowolenie")}
+              style={{ gridColumn: "span 2" }}
+            >
+              <p style={{ margin: "0 0 6px", color: "#6b7280", fontSize: 11 }}>
+                Dane pochodzą z badań społecznych przeprowadzonych w 2024 roku wśród mieszkańców gmin Metropolii Krakowskiej.
+              </p>
+              <div style={{ height: 320 }}>
+                <iframe
+                  title="Poziom zadowolenia mieszkańców"
+                  src="https://experience.arcgis.com/experience/51fd6fd2e6514e5ea7b17d5a60163f14/"
+                  style={{ width: "100%", height: "100%", border: 0 }}
+                  loading="lazy"
+                  allowFullScreen
+                />
+              </div>
+            </Card>
 
-            <div style={{ breakInside: "avoid", marginBottom: 12 }}>
-              <Card
-                title="Dochody ogółem na 1 mieszkańca"
-                subtitle="Źródło: ArcGIS Experience"
-                height={380}
-                onOpen={() => setOpenCard("dochody")}
-              >
-                <div style={{ height: 320 }}>
-                  <iframe
-                    title="Dochody ogółem na 1 mieszkańca"
-                    src="https://experience.arcgis.com/experience/24d07761e5e743b6a072e04bbbf8d4b4/"
-                    style={{ width: "100%", height: "100%", border: 0 }}
-                    loading="lazy"
-                    allowFullScreen
-                  />
-                </div>
-              </Card>
-            </div>
+            <Card
+              title="Poziom zadowolenia — Metropolia"
+              subtitle="Źródło: Raport z badań społecznych 2024"
+              height={420}
+              onOpen={() => setOpenCard("poziom")}
+            >
+              <p style={{ margin: "0 0 6px", color: "#6b7280", fontSize: 11 }}>
+                Dane pochodzą z badań społecznych przeprowadzonych w 2024 roku wśród mieszkańców gmin Metropolii Krakowskiej.
+              </p>
+              <div style={{ height: 320 }}>
+                <ResponsiveContainer width="100%" height="100%">
+                  <BarChart
+                    data={[
+                      { kategoria: "Pozytywne", odsetek: 66 },
+                      { kategoria: "Neutralne", odsetek: 31 },
+                      { kategoria: "Negatywne", odsetek: 3 },
+                    ]}
+                    margin={{ top: 8, right: 8, bottom: 16, left: 8 }}
+                  >
+                    <CartesianGrid vertical={false} stroke="#eee" />
+                    <XAxis dataKey="kategoria" tick={{ fontSize: 11 }} />
+                    <YAxis unit="%" tick={{ fontSize: 11 }} />
+                    <Tooltip
+                      formatter={(v: number) => [`${v}%`, "odsetek"]}
+                      labelStyle={{ fontSize: 11 }}
+                      itemStyle={{ fontSize: 11 }}
+                    />
+                    <Bar
+                      dataKey="odsetek"
+                      name="Poziom zadowolenia [%]"
+                      fill="rgb(135, 135, 135)"
+                    />
+                  </BarChart>
+                </ResponsiveContainer>
+              </div>
+            </Card>
 
-            <div style={{ breakInside: "avoid", marginBottom: 12 }}>
-              <Card
-                title="Poziom zadowolenia — Metropolia"
-                subtitle="Opracowanie własne"
-                height={340}
-                onOpen={() => setOpenCard("poziom")}
-              >
-                <div style={{ height: 280 }}>
-                  <ResponsiveContainer width="100%" height="100%">
-                    <BarChart
-                      data={[
-                        { kategoria: "Pozytywne", odsetek: 66 },
-                        { kategoria: "Neutralne", odsetek: 31 },
-                        { kategoria: "Negatywne", odsetek: 3 },
-                      ]}
-                      margin={{ top: 8, right: 8, bottom: 16, left: 8 }}
-                    >
-                      <CartesianGrid vertical={false} stroke="#eee" />
-                      <XAxis dataKey="kategoria" tick={{ fontSize: 11 }} />
-                      <YAxis unit="%" tick={{ fontSize: 11 }} />
-                      <Tooltip
-                        formatter={(v: number) => [`${v}%`, "odsetek"]}
-                        labelStyle={{ fontSize: 11 }}
-                        itemStyle={{ fontSize: 11 }}
-                      />
-                      <Bar
-                        dataKey="odsetek"
-                        name="Poziom zadowolenia [%]"
-                        fill="rgb(135, 135, 135)"
-                      />
-                    </BarChart>
-                  </ResponsiveContainer>
-                </div>
-              </Card>
-            </div>
+            <Card
+              title="Dochody ogółem na 1 mieszkańca"
+              subtitle="Źródło: ArcGIS Experience"
+              height={300}
+              onOpen={() => setOpenCard("dochody")}
+              style={{ gridColumn: "span 2" }}
+            >
+              <div style={{ height: 240 }}>
+                <iframe
+                  title="Dochody ogółem na 1 mieszkańca"
+                  src="https://experience.arcgis.com/experience/24d07761e5e743b6a072e04bbbf8d4b4/"
+                  style={{ width: "100%", height: "100%", border: 0 }}
+                  loading="lazy"
+                  allowFullScreen
+                />
+              </div>
+            </Card>
 
-            <div style={{ breakInside: "avoid", marginBottom: 12 }}>
-              <Card
-                title="Zadłużenie Gminy [%]"
-                subtitle="Źródło: Ministerstwo Finansów"
-                height={380}
-                onOpen={() => setOpenCard("zadluzenie")}
-              >
-                <div style={{ height: 320 }}>
-                  <ResponsiveContainer width="100%" height="100%">
-                    <BarChart
-                      data={[
-                        { gmina: "Kraków", wartosc: 75.9 },
-                        { gmina: "Wieliczka", wartosc: 63.2 },
-                        { gmina: "Niepołomice", wartosc: 57.9 },
-                        { gmina: "Zabierzów", wartosc: 49.7 },
-                        { gmina: "Świątniki Górne", wartosc: 46.0 },
-                        { gmina: "Czernichów", wartosc: 35.7 },
-                        { gmina: "Liszki", wartosc: 37.8 },
-                        { gmina: "Skawina", wartosc: 33.1 },
-                        { gmina: "Biskupice", wartosc: 31.0 },
-                        { gmina: "Mogilany", wartosc: 29.8 },
-                        { gmina: "Kocmyrzów-Luborzyca", wartosc: 26.3 },
-                        { gmina: "Michałowice", wartosc: 14.0 },
-                        { gmina: "Zielonki", wartosc: 13.8 },
-                        { gmina: "Wielka Wieś", wartosc: 8.3 },
-                        { gmina: "Igołomia-Wawrzeńczyce", wartosc: 7.5 },
-                      ]
-                        .slice()
-                        .sort((a, b) => b.wartosc - a.wartosc)}
-                      margin={{ top: 8, right: 8, bottom: 84, left: 8 }}
-                    >
-                      <CartesianGrid vertical={false} stroke="#eee" />
-                      <XAxis
-                        dataKey="gmina"
-                        angle={-35}
-                        textAnchor="end"
-                        interval={0}
-                        height={60}
-                        tick={{ fontSize: 11 }}
-                      />
-                      <YAxis unit="%" tick={{ fontSize: 11 }} />
-                      <Tooltip
-                        formatter={(v: number) => [`${v}%`, "zadłużenie"]}
-                        labelStyle={{ fontSize: 11 }}
-                        itemStyle={{ fontSize: 11 }}
-                      />
-                      <Bar
-                        dataKey="wartosc"
-                        name="Zadłużenie gminy [%]"
-                        fill="rgb(178, 178, 178)"
-                      />
-                    </BarChart>
-                  </ResponsiveContainer>
-                </div>
-              </Card>
-            </div>
+            <Card
+              title="Zadłużenie Gminy [%]"
+              subtitle="Źródło: Ministerstwo Finansów"
+              height={300}
+              onOpen={() => setOpenCard("zadluzenie")}
+            >
+              <div style={{ height: 240 }}>
+                <ResponsiveContainer width="100%" height="100%">
+                  <BarChart
+                    data={[
+                      { gmina: "Kraków", wartosc: 75.9 },
+                      { gmina: "Wieliczka", wartosc: 63.2 },
+                      { gmina: "Niepołomice", wartosc: 57.9 },
+                      { gmina: "Zabierzów", wartosc: 49.7 },
+                      { gmina: "Świątniki Górne", wartosc: 46.0 },
+                      { gmina: "Czernichów", wartosc: 35.7 },
+                      { gmina: "Liszki", wartosc: 37.8 },
+                      { gmina: "Skawina", wartosc: 33.1 },
+                      { gmina: "Biskupice", wartosc: 31.0 },
+                      { gmina: "Mogilany", wartosc: 29.8 },
+                      { gmina: "Kocmyrzów-Luborzyca", wartosc: 26.3 },
+                      { gmina: "Michałowice", wartosc: 14.0 },
+                      { gmina: "Zielonki", wartosc: 13.8 },
+                      { gmina: "Wielka Wieś", wartosc: 8.3 },
+                      { gmina: "Igołomia-Wawrzeńczyce", wartosc: 7.5 },
+                    ]
+                      .slice()
+                      .sort((a, b) => b.wartosc - a.wartosc)}
+                    margin={{ top: 8, right: 8, bottom: 84, left: 8 }}
+                  >
+                    <CartesianGrid vertical={false} stroke="#eee" />
+                    <XAxis
+                      dataKey="gmina"
+                      angle={-35}
+                      textAnchor="end"
+                      interval={0}
+                      height={60}
+                      tick={{ fontSize: 11 }}
+                    />
+                    <YAxis unit="%" tick={{ fontSize: 11 }} />
+                    <Tooltip
+                      formatter={(v: number) => [`${v}%`, "zadłużenie"]}
+                      labelStyle={{ fontSize: 11 }}
+                      itemStyle={{ fontSize: 11 }}
+                    />
+                    <Bar
+                      dataKey="wartosc"
+                      name="Zadłużenie gminy [%]"
+                      fill="rgb(178, 178, 178)"
+                    />
+                  </BarChart>
+                </ResponsiveContainer>
+              </div>
+            </Card>
 
-            <div style={{ breakInside: "avoid", marginBottom: 12 }}>
-              <Card
-                title="Wzrost wpływów z PIT (2023–2024)"
-                subtitle="Źródło: BDL GUS"
-                height={380}
-                onOpen={() => setOpenCard("pit")}
-              >
-                <div style={{ height: 320 }}>
-                  <ResponsiveContainer width="100%" height="100%">
-                    <BarChart
-                      data={[
-                        {
-                          gmina: "Czernichów",
-                          v2023: 16717378,
-                          v2024: 26955832,
-                        },
-                        {
-                          gmina: "Igołomia-Wawrzeńczyce",
-                          v2023: 4833642,
-                          v2024: 8404042,
-                        },
-                        {
-                          gmina: "Kocmyrzów-Luborzyca",
-                          v2023: 23726968,
-                          v2024: 33275448,
-                        },
-                        { gmina: "Liszki", v2023: 19296648, v2024: 31817505 },
-                        {
-                          gmina: "Michałowice",
-                          v2023: 19421383,
-                          v2024: 32443084,
-                        },
-                        { gmina: "Mogilany", v2023: 27641595, v2024: 47957513 },
-                        { gmina: "Skawina", v2023: 46053181, v2024: 72403208 },
-                        {
-                          gmina: "Świątniki Górne",
-                          v2023: 18885311,
-                          v2024: 29586555,
-                        },
-                        {
-                          gmina: "Wielka Wieś",
-                          v2023: 24216556,
-                          v2024: 43581177,
-                        },
-                        {
-                          gmina: "Zabierzów",
-                          v2023: 44758719,
-                          v2024: 75616706,
-                        },
-                        { gmina: "Zielonki", v2023: 49584707, v2024: 85914146 },
-                        {
-                          gmina: "Biskupice",
-                          v2023: 10102509,
-                          v2024: 16340114,
-                        },
-                        {
-                          gmina: "Niepołomice",
-                          v2023: 35760781,
-                          v2024: 59543802,
-                        },
-                        {
-                          gmina: "Wieliczka",
-                          v2023: 82118011,
-                          v2024: 134722367,
-                        },
-                        {
-                          gmina: "Kraków",
-                          v2023: 1710047660,
-                          v2024: 2803318933,
-                        },
-                      ]
-                        .map((r) => ({
-                          gmina: r.gmina,
-                          wzrost: Number(
-                            ((r.v2024 / r.v2023 - 1) * 100).toFixed(2)
-                          ),
-                        }))
-                        .sort((a, b) => b.wzrost - a.wzrost)}
-                      margin={{ top: 8, right: 8, bottom: 84, left: 8 }}
-                    >
-                      <CartesianGrid vertical={false} stroke="#eee" />
-                      <XAxis
-                        dataKey="gmina"
-                        angle={-35}
-                        textAnchor="end"
-                        interval={0}
-                        height={60}
-                        tick={{ fontSize: 11 }}
-                      />
-                      <YAxis unit="%" tick={{ fontSize: 11 }} />
-                      <Tooltip
-                        formatter={(v: number) => [`${v}%`, "zmiana 2023–2024"]}
-                        labelStyle={{ fontSize: 11 }}
-                        itemStyle={{ fontSize: 11 }}
-                      />
-                      <Bar
-                        dataKey="wzrost"
-                        name="2023–2024 [%]"
-                        fill="rgb(135, 135, 135)"
-                      />
-                    </BarChart>
-                  </ResponsiveContainer>
-                </div>
-              </Card>
-            </div>
+            <Card
+              title="Wzrost wpływów z PIT (2023–2024)"
+              subtitle="Źródło: BDL GUS"
+              height={300}
+              onOpen={() => setOpenCard("pit")}
+            >
+              <div style={{ height: 240 }}>
+                <ResponsiveContainer width="100%" height="100%">
+                  <BarChart
+                    data={[
+                      {
+                        gmina: "Czernichów",
+                        v2023: 16717378,
+                        v2024: 26955832,
+                      },
+                      {
+                        gmina: "Igołomia-Wawrzeńczyce",
+                        v2023: 4833642,
+                        v2024: 8404042,
+                      },
+                      {
+                        gmina: "Kocmyrzów-Luborzyca",
+                        v2023: 23726968,
+                        v2024: 33275448,
+                      },
+                      { gmina: "Liszki", v2023: 19296648, v2024: 31817505 },
+                      {
+                        gmina: "Michałowice",
+                        v2023: 19421383,
+                        v2024: 32443084,
+                      },
+                      { gmina: "Mogilany", v2023: 27641595, v2024: 47957513 },
+                      { gmina: "Skawina", v2023: 46053181, v2024: 72403208 },
+                      {
+                        gmina: "Świątniki Górne",
+                        v2023: 18885311,
+                        v2024: 29586555,
+                      },
+                      {
+                        gmina: "Wielka Wieś",
+                        v2023: 24216556,
+                        v2024: 43581177,
+                      },
+                      {
+                        gmina: "Zabierzów",
+                        v2023: 44758719,
+                        v2024: 75616706,
+                      },
+                      { gmina: "Zielonki", v2023: 49584707, v2024: 85914146 },
+                      {
+                        gmina: "Biskupice",
+                        v2023: 10102509,
+                        v2024: 16340114,
+                      },
+                      {
+                        gmina: "Niepołomice",
+                        v2023: 35760781,
+                        v2024: 59543802,
+                      },
+                      {
+                        gmina: "Wieliczka",
+                        v2023: 82118011,
+                        v2024: 134722367,
+                      },
+                      {
+                        gmina: "Kraków",
+                        v2023: 1710047660,
+                        v2024: 2803318933,
+                      },
+                    ]
+                      .map((r) => ({
+                        gmina: r.gmina,
+                        wzrost: Number(
+                          ((r.v2024 / r.v2023 - 1) * 100).toFixed(2)
+                        ),
+                      }))
+                      .sort((a, b) => b.wzrost - a.wzrost)}
+                    margin={{ top: 8, right: 8, bottom: 84, left: 8 }}
+                  >
+                    <CartesianGrid vertical={false} stroke="#eee" />
+                    <XAxis
+                      dataKey="gmina"
+                      angle={-35}
+                      textAnchor="end"
+                      interval={0}
+                      height={60}
+                      tick={{ fontSize: 11 }}
+                    />
+                    <YAxis unit="%" tick={{ fontSize: 11 }} />
+                    <Tooltip
+                      formatter={(v: number) => [`${v}%`, "zmiana 2023–2024"]}
+                      labelStyle={{ fontSize: 11 }}
+                      itemStyle={{ fontSize: 11 }}
+                    />
+                    <Bar
+                      dataKey="wzrost"
+                      name="2023–2024 [%]"
+                      fill="rgb(135, 135, 135)"
+                    />
+                  </BarChart>
+                </ResponsiveContainer>
+              </div>
+            </Card>
 
-            <div style={{ breakInside: "avoid", marginBottom: 12 }}>
-              <Card
-                title="Wzrost wpływów z CIT (2019–2024)"
-                subtitle="Źródło: BDL GUS"
-                height={380}
-                onOpen={() => setOpenCard("cit")}
-              >
-                <div style={{ height: 320 }}>
+            <Card
+              title="Wzrost wpływów z CIT (2019–2024)"
+              subtitle="Źródło: BDL GUS"
+              height={300}
+              onOpen={() => setOpenCard("cit")}
+            >
+              <div style={{ height: 240 }}>
                   <ResponsiveContainer width="100%" height="100%">
                     <BarChart
                       data={[

--- a/mk-dashboard/src/pages/KulturaCzasuWolnego.tsx
+++ b/mk-dashboard/src/pages/KulturaCzasuWolnego.tsx
@@ -17,8 +17,8 @@ import {
 } from "recharts";
 
 export default function KulturaCzasuWolnego() {
-  const [scale, setScale] = useState(1);
   const [openCard, setOpenCard] = useState<string | null>(null);
+  const [scale, setScale] = useState(1);
   const Y: Rok = 2024;
   const CZYTELNICY_2024: Record<Gmina, number> = {
     Czernichów: 1818,
@@ -65,216 +65,207 @@ export default function KulturaCzasuWolnego() {
             overflow: "hidden",
             display: "flex",
             justifyContent: "center",
-            alignItems: "flex-start",
+            padding: "0 32px",
           }}
         >
           <div
             style={{
-              columnCount: 3,
-              columnGap: 12,
               transformOrigin: "top center",
               transform: `scale(${scale})`,
               width: "100%",
+              maxWidth: "1800px",
             }}
             ref={(el) => {
               if (el && el.parentElement?.parentElement) {
                 const container = el.parentElement.parentElement;
                 const updateScale = () => {
                   const containerHeight = container.clientHeight;
-                  const containerWidth = container.clientWidth;
-
                   el.style.transform = "scale(1)";
                   const contentHeight = el.scrollHeight;
-                  const contentWidth = el.scrollWidth;
                   el.style.transform = `scale(${scale})`;
-
                   const heightScale = containerHeight / contentHeight;
-                  const widthScale = containerWidth / contentWidth;
-
-                  let newScale = Math.min(heightScale, widthScale, 1);
-                  newScale = Math.max(0.5, Math.min(1, newScale));
-
+                  let newScale = Math.min(heightScale, 1);
+                  newScale = Math.max(0.4, Math.min(1, newScale));
                   setScale(newScale);
                 };
-
                 setTimeout(updateScale, 100);
                 setTimeout(updateScale, 500);
-
                 const resizeObserver = new ResizeObserver(() => {
                   setTimeout(updateScale, 50);
                 });
                 resizeObserver.observe(container);
-
                 return () => resizeObserver.disconnect();
               }
             }}
           >
-            <div style={{ breakInside: "avoid", marginBottom: 12 }}>
-              <Card
+            <div
+              style={{
+                display: "grid",
+                gridTemplateColumns: "repeat(3, 1fr)",
+                gap: 12,
+              }}
+            >
+        <div style={{ gridColumn: "span 2" }}>
+          <Card
+            title="Zadowolenie z oferty czasu wolnego"
+            subtitle="Źródło: ArcGIS Experience"
+            height={420}
+            onOpen={() => setOpenCard("zadowolenie")}
+          >
+            <div style={{ height: 360 }}>
+              <iframe
                 title="Zadowolenie z oferty czasu wolnego"
-                subtitle="Źródło: ArcGIS Experience"
-                height={380}
-                onOpen={() => setOpenCard("zadowolenie")}
-              >
-                <div style={{ height: 320 }}>
-                  <iframe
-                    title="Zadowolenie z oferty czasu wolnego"
-                    src="https://experience.arcgis.com/experience/35fe8984c18a4a0bb3237fbd13eeaf99/"
-                    style={{ width: "100%", height: "100%", border: 0 }}
-                    loading="lazy"
-                    allowFullScreen
-                  />
-                </div>
-              </Card>
+                src="https://experience.arcgis.com/experience/35fe8984c18a4a0bb3237fbd13eeaf99/"
+                style={{ width: "100%", height: "100%", border: 0 }}
+                loading="lazy"
+                allowFullScreen
+              />
             </div>
+          </Card>
+        </div>
 
-            <div style={{ breakInside: "avoid", marginBottom: 12 }}>
-              <Card
+        <Card
+          title="Czytelnicy w bibliotekach (2019–2024)"
+          subtitle="Źródło: BDL GUS"
+          height={420}
+          onOpen={() => setOpenCard("czytelnicy")}
+        >
+          <div style={{ height: 360 }}>
+            <ResponsiveContainer width="100%" height="100%">
+              <LineChart
+                data={[
+                  { rok: "2019", czytelnicy: 273726 },
+                  { rok: "2020", czytelnicy: 227670 },
+                  { rok: "2021", czytelnicy: 225261 },
+                  { rok: "2022", czytelnicy: 248901 },
+                  { rok: "2023", czytelnicy: 280700 },
+                  { rok: "2024", czytelnicy: 300983 },
+                ]}
+                margin={{ top: 8, right: 8, bottom: 16, left: 8 }}
+              >
+                <CartesianGrid vertical={false} stroke="#eee" />
+                <XAxis dataKey="rok" tick={{ fontSize: 11 }} />
+                <YAxis
+                  domain={["dataMin - 10000", "dataMax + 10000"]}
+                  tickFormatter={(value) =>
+                    new Intl.NumberFormat("pl-PL", {
+                      notation: "compact",
+                      minimumFractionDigits: 0,
+                      maximumFractionDigits: 0,
+                    }).format(value)
+                  }
+                  tick={{ fontSize: 11 }}
+                />
+                <Tooltip
+                  formatter={(v: number) => [
+                    new Intl.NumberFormat("pl-PL").format(v),
+                    "czytelnicy",
+                  ]}
+                  labelStyle={{ fontSize: 11 }}
+                  itemStyle={{ fontSize: 11 }}
+                />
+                <Line
+                  type="monotone"
+                  dataKey="czytelnicy"
+                  name="Czytelnicy"
+                  stroke="rgb(144, 12, 0)"
+                  strokeWidth={2}
+                  dot={{ r: 4 }}
+                />
+              </LineChart>
+            </ResponsiveContainer>
+          </div>
+        </Card>
+
+        <div style={{ gridColumn: "span 2" }}>
+          <Card
+            title="Wydatki na kulturę i sport"
+            subtitle="Źródło: ArcGIS Experience"
+            height={420}
+            onOpen={() => setOpenCard("wydatki")}
+          >
+            <div style={{ height: 360 }}>
+              <iframe
                 title="Wydatki na kulturę i sport"
-                subtitle="Źródło: ArcGIS Experience"
-                height={380}
-                onOpen={() => setOpenCard("wydatki")}
-              >
-                <div style={{ height: 320 }}>
-                  <iframe
-                    title="Wydatki na kulturę i sport"
-                    src="https://experience.arcgis.com/experience/e3e555c99ff14d489a8336573bad3166/"
-                    style={{ width: "100%", height: "100%", border: 0 }}
-                    loading="lazy"
-                    allowFullScreen
-                  />
-                </div>
-              </Card>
+                src="https://experience.arcgis.com/experience/e3e555c99ff14d489a8336573bad3166/"
+                style={{ width: "100%", height: "100%", border: 0 }}
+                loading="lazy"
+                allowFullScreen
+              />
             </div>
+          </Card>
+        </div>
 
-            <div style={{ breakInside: "avoid", marginBottom: 12 }}>
-              <Card
-                title="Czytelnicy w bibliotekach (2019–2024)"
-                subtitle="Źródło: BDL GUS"
-                height={340}
-                onOpen={() => setOpenCard("czytelnicy")}
+        <Card
+          title="Czytelnicy na 1 tys. mieszkańców"
+          subtitle="Źródło: BDL GUS"
+          height={420}
+          onOpen={() => setOpenCard("czytelnicyTys")}
+        >
+          <div style={{ height: 360 }}>
+            <ResponsiveContainer width="100%" height="100%">
+              <BarChart
+                data={GMINY.map((g) => {
+                  const readers = CZYTELNICY_2024[g as Gmina] || 0;
+                  const pop = computeLudnosc(g as Gmina, Y);
+                  const perThousand = pop ? (readers / pop) * 1000 : 0;
+                  return {
+                    gmina: g,
+                    wartosc: Number(perThousand.toFixed(1)),
+                  };
+                })
+                  .slice()
+                  .sort((a, b) => b.wartosc - a.wartosc)}
+                margin={{ top: 8, right: 8, bottom: 84, left: 8 }}
               >
-                <div style={{ height: 280 }}>
-                  <ResponsiveContainer width="100%" height="100%">
-                    <LineChart
-                      data={[
-                        { rok: "2019", czytelnicy: 273726 },
-                        { rok: "2020", czytelnicy: 227670 },
-                        { rok: "2021", czytelnicy: 225261 },
-                        { rok: "2022", czytelnicy: 248901 },
-                        { rok: "2023", czytelnicy: 280700 },
-                        { rok: "2024", czytelnicy: 300983 },
-                      ]}
-                      margin={{ top: 8, right: 8, bottom: 16, left: 8 }}
-                    >
-                      <CartesianGrid vertical={false} stroke="#eee" />
-                      <XAxis dataKey="rok" tick={{ fontSize: 11 }} />
-                      <YAxis
-                        domain={["dataMin - 10000", "dataMax + 10000"]}
-                        tickFormatter={(value) =>
-                          new Intl.NumberFormat("pl-PL", {
-                            notation: "compact",
-                            minimumFractionDigits: 0,
-                            maximumFractionDigits: 0,
-                          }).format(value)
-                        }
-                        tick={{ fontSize: 11 }}
-                      />
-                      <Tooltip
-                        formatter={(v: number) => [
-                          new Intl.NumberFormat("pl-PL").format(v),
-                          "czytelnicy",
-                        ]}
-                        labelStyle={{ fontSize: 11 }}
-                        itemStyle={{ fontSize: 11 }}
-                      />
-                      <Line
-                        type="monotone"
-                        dataKey="czytelnicy"
-                        name="Czytelnicy"
-                        stroke="rgb(144, 12, 0)"
-                        strokeWidth={2}
-                        dot={{ r: 4 }}
-                      />
-                    </LineChart>
-                  </ResponsiveContainer>
-                </div>
-              </Card>
-            </div>
+                <CartesianGrid vertical={false} stroke="#eee" />
+                <XAxis
+                  dataKey="gmina"
+                  angle={-35}
+                  textAnchor="end"
+                  interval={0}
+                  height={60}
+                  tick={{ fontSize: 11 }}
+                />
+                <YAxis tick={{ fontSize: 11 }} />
+                <Tooltip
+                  formatter={(v: number) => [
+                    `${(v as number).toFixed(1)}`,
+                    "na 1 tys. mieszk.",
+                  ]}
+                  labelStyle={{ fontSize: 11 }}
+                  itemStyle={{ fontSize: 11 }}
+                />
+                <Bar
+                  dataKey="wartosc"
+                  name="Czytelnicy na 1 tys. mieszkańców"
+                  fill="rgb(205, 25, 0)"
+                />
+              </BarChart>
+            </ResponsiveContainer>
+          </div>
+        </Card>
 
-            <div style={{ breakInside: "avoid", marginBottom: 12 }}>
-              <Card
-                title="Czytelnicy na 1 tys. mieszkańców"
-                subtitle="Źródło: BDL GUS"
-                height={380}
-                onOpen={() => setOpenCard("czytelnicyTys")}
-              >
-                <div style={{ height: 320 }}>
-                  <ResponsiveContainer width="100%" height="100%">
-                    <BarChart
-                      data={GMINY.map((g) => {
-                        const readers = CZYTELNICY_2024[g as Gmina] || 0;
-                        const pop = computeLudnosc(g as Gmina, Y);
-                        const perThousand = pop ? (readers / pop) * 1000 : 0;
-                        return {
-                          gmina: g,
-                          wartosc: Number(perThousand.toFixed(1)),
-                        };
-                      })
-                        .slice()
-                        .sort((a, b) => b.wartosc - a.wartosc)}
-                      margin={{ top: 8, right: 8, bottom: 84, left: 8 }}
-                    >
-                      <CartesianGrid vertical={false} stroke="#eee" />
-                      <XAxis
-                        dataKey="gmina"
-                        angle={-35}
-                        textAnchor="end"
-                        interval={0}
-                        height={60}
-                        tick={{ fontSize: 11 }}
-                      />
-                      <YAxis tick={{ fontSize: 11 }} />
-                      <Tooltip
-                        formatter={(v: number) => [
-                          `${(v as number).toFixed(1)}`,
-                          "na 1 tys. mieszk.",
-                        ]}
-                        labelStyle={{ fontSize: 11 }}
-                        itemStyle={{ fontSize: 11 }}
-                      />
-                      <Bar
-                        dataKey="wartosc"
-                        name="Czytelnicy na 1 tys. mieszkańców"
-                        fill="rgb(205, 25, 0)"
-                      />
-                    </BarChart>
-                  </ResponsiveContainer>
-                </div>
-              </Card>
-            </div>
-
-            <div style={{ breakInside: "avoid", marginBottom: 12 }}>
-              <Card
-                title="Biblioteki publiczne"
-                subtitle="Źródło: BDL GUS"
-                height={200}
-                onOpen={() => setOpenCard("biblioteki")}
-              >
-                <div
-                  style={{
-                    height: 140,
-                    display: "flex",
-                    alignItems: "center",
-                    justifyContent: "center",
-                    fontSize: "24px",
-                    fontWeight: "bold",
-                    color: "rgb(144, 12, 0)",
-                  }}
-                >
-                  0.95 bibliotek na 10 tys. mieszkańców
-                </div>
-              </Card>
+        <Card
+          title="Biblioteki publiczne"
+          subtitle="Źródło: BDL GUS"
+          height={180}
+          onOpen={() => setOpenCard("biblioteki")}
+        >
+          <div
+            style={{
+              height: 120,
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              fontSize: "24px",
+              fontWeight: "bold",
+              color: "rgb(144, 12, 0)",
+            }}
+          >
+            0.95 bibliotek na 10 tys. mieszkańców
+          </div>
+        </Card>
             </div>
           </div>
         </div>

--- a/mk-dashboard/src/pages/Mobilnosc.tsx
+++ b/mk-dashboard/src/pages/Mobilnosc.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useRef, useEffect } from "react";
 import Card from "../components/Card";
 import Modal from "../components/Modal";
 import {
@@ -12,8 +12,28 @@ import {
 } from "recharts";
 
 export default function Mobilnosc() {
-  const [scale, setScale] = useState(1);
   const [openCard, setOpenCard] = useState<string | null>(null);
+  const [scale, setScale] = useState(1);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const contentRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    const content = contentRef.current;
+    if (!container || !content) return;
+
+    const observer = new ResizeObserver(() => {
+      const containerHeight = container.clientHeight;
+      const contentHeight = content.scrollHeight;
+      if (contentHeight > 0) {
+        const newScale = Math.min(1, containerHeight / contentHeight);
+        setScale(newScale);
+      }
+    });
+
+    observer.observe(container);
+    return () => observer.disconnect();
+  }, []);
 
   return (
     <div
@@ -28,6 +48,7 @@ export default function Mobilnosc() {
         Mobilność
       </h2>
       <div
+        ref={containerRef}
         style={{
           flex: 1,
           minHeight: 0,
@@ -39,293 +60,223 @@ export default function Mobilnosc() {
           style={{
             position: "absolute",
             inset: 0,
-            overflow: "hidden",
             display: "flex",
-            justifyContent: "flex-start",
+            justifyContent: "center",
             alignItems: "flex-start",
-            padding: "0 12px",
+            padding: "0 32px",
           }}
         >
           <div
+            ref={contentRef}
             style={{
-              columnCount: 3,
-              columnGap: 12,
-              transformOrigin: "top left",
               transform: `scale(${scale})`,
+              transformOrigin: "top center",
               width: "100%",
-              maxWidth: "100%",
-            }}
-            ref={(el) => {
-              if (el && el.parentElement?.parentElement) {
-                const container = el.parentElement.parentElement;
-                const updateScale = () => {
-                  const containerHeight = container.clientHeight;
-                  const containerWidth = container.clientWidth;
-
-                  el.style.transform = "scale(1)";
-                  const contentHeight = el.scrollHeight;
-                  const contentWidth = el.scrollWidth;
-                  el.style.transform = `scale(${scale})`;
-
-                  const heightScale = containerHeight / contentHeight;
-                  const widthScale = containerWidth / contentWidth;
-
-                  let newScale = Math.min(heightScale, widthScale, 1);
-                  newScale = Math.max(0.5, Math.min(1, newScale));
-
-                  setScale(newScale);
-                };
-
-                setTimeout(updateScale, 100);
-                setTimeout(updateScale, 500);
-
-                const resizeObserver = new ResizeObserver(() => {
-                  setTimeout(updateScale, 50);
-                });
-                resizeObserver.observe(container);
-
-                return () => resizeObserver.disconnect();
-              }
+              maxWidth: "1800px",
             }}
           >
-            <div style={{ breakInside: "avoid", marginBottom: 12 }}>
-              <Card
+            <div
+              style={{
+                display: "grid",
+                gridTemplateColumns: "repeat(3, 1fr)",
+                gap: 12,
+              }}
+            >
+          <Card
+            title="Transport publiczny"
+            subtitle="Źródło: ArcGIS Experience"
+            height={400}
+            style={{ gridColumn: "span 2" }}
+          >
+            <div style={{ height: 340 }}>
+              <iframe
                 title="Transport publiczny"
-                subtitle="Źródło: ArcGIS Experience"
-                height={380}
-              >
-                <div style={{ height: 320 }}>
-                  <iframe
-                    title="Transport publiczny"
-                    src="https://experience.arcgis.com/experience/26dbf3298caf4f4ea6a0a3e0cfb7f1bf/"
-                    style={{ width: "100%", height: "100%", border: 0 }}
-                    loading="lazy"
-                    allowFullScreen
-                  />
-                </div>
-              </Card>
+                src="https://experience.arcgis.com/experience/26dbf3298caf4f4ea6a0a3e0cfb7f1bf/"
+                style={{ width: "100%", height: "100%", border: 0 }}
+                loading="lazy"
+                allowFullScreen
+              />
             </div>
+          </Card>
 
-            <div style={{ breakInside: "avoid", marginBottom: 12 }}>
-              <Card
+          <Card
+            title="Czynniki wyboru środka transportu"
+            subtitle="Źródło: Raport z badań społecznych 2024"
+            height={340}
+            onOpen={() => setOpenCard("czynniki")}
+          >
+            <div style={{ height: 280 }}>
+              <ResponsiveContainer width="100%" height="100%">
+                <BarChart
+                  data={[
+                    { czynnik: "Komfort podróży", odsetek: 59 },
+                    {
+                      czynnik: "Brak alternatywy",
+                      odsetek: 15,
+                    },
+                    { czynnik: "Czas przejazdu", odsetek: 13 },
+                    { czynnik: "Koszty", odsetek: 5 },
+                    { czynnik: "Bezpieczeństwo", odsetek: 4 },
+                    { czynnik: "Inne", odsetek: 3 },
+                    { czynnik: "Środowisko", odsetek: 1 },
+                  ]}
+                  margin={{ top: 8, right: 8, bottom: 16, left: 8 }}
+                >
+                  <CartesianGrid vertical={false} stroke="#eee" />
+                  <XAxis
+                    dataKey="czynnik"
+                    interval={0}
+                    angle={-15}
+                    textAnchor="end"
+                    height={60}
+                    tick={{ fontSize: 11 }}
+                  />
+                  <YAxis unit="%" tick={{ fontSize: 11 }} />
+                  <Tooltip
+                    formatter={(v: number) => [`${v}%`, "odsetek"]}
+                    labelStyle={{ fontSize: 11 }}
+                    itemStyle={{ fontSize: 11 }}
+                  />
+                  <Bar
+                    dataKey="odsetek"
+                    name="Udział odpowiedzi [%]"
+                    fill="rgb(29, 113, 184)"
+                  />
+                </BarChart>
+              </ResponsiveContainer>
+            </div>
+          </Card>
+
+          <Card
+            title="Transport samochodowy"
+            subtitle="Źródło: ArcGIS Experience"
+            height={420}
+            style={{ gridColumn: "span 2" }}
+          >
+            <div style={{ height: 360 }}>
+              <iframe
                 title="Transport samochodowy"
-                subtitle="Źródło: ArcGIS Experience"
-                height={380}
-              >
-                <div style={{ height: 320 }}>
-                  <iframe
-                    title="Transport samochodowy"
-                    src="https://experience.arcgis.com/experience/d995260ef5bb475488dd2275d6587bf2/"
-                    style={{ width: "100%", height: "100%", border: 0 }}
-                    loading="lazy"
-                    allowFullScreen
-                  />
-                </div>
-              </Card>
+                src="https://experience.arcgis.com/experience/d995260ef5bb475488dd2275d6587bf2/"
+                style={{ width: "100%", height: "100%", border: 0 }}
+                loading="lazy"
+                allowFullScreen
+              />
             </div>
+          </Card>
 
-            <div style={{ breakInside: "avoid", marginBottom: 12 }}>
-              <Card
+          <Card
+            title="Podział modalny podróży"
+            subtitle="Źródło: Raport z badań społecznych 2024"
+            height={340}
+            onOpen={() => setOpenCard("podzial")}
+          >
+            <div style={{ height: 280 }}>
+              <ResponsiveContainer width="100%" height="100%">
+                <BarChart
+                  data={[
+                    { srodek: "Samochód", udzial: 63 },
+                    { srodek: "Komunikacja", udzial: 22 },
+                    { srodek: "Pieszo", udzial: 10 },
+                    { srodek: "Rower", udzial: 3 },
+                    { srodek: "Pociąg", udzial: 0.8 },
+                    { srodek: "Hulajnoga", udzial: 0.4 },
+                  ]}
+                  margin={{ top: 8, right: 8, bottom: 16, left: 8 }}
+                >
+                  <CartesianGrid vertical={false} stroke="#eee" />
+                  <XAxis
+                    dataKey="srodek"
+                    interval={0}
+                    angle={-15}
+                    textAnchor="end"
+                    height={60}
+                    tick={{ fontSize: 11 }}
+                  />
+                  <YAxis unit="%" tick={{ fontSize: 11 }} />
+                  <Tooltip
+                    formatter={(v: number) => [
+                      `${Number(v).toFixed(v < 1 ? 1 : 0)}%`,
+                      "udział",
+                    ]}
+                    labelStyle={{ fontSize: 11 }}
+                    itemStyle={{ fontSize: 11 }}
+                  />
+                  <Bar
+                    dataKey="udzial"
+                    name="Udział podróży [%]"
+                    fill="rgb(54, 169, 225)"
+                  />
+                </BarChart>
+              </ResponsiveContainer>
+            </div>
+          </Card>
+
+          <Card
+            title="Transport rowerowy"
+            subtitle="Źródło: ArcGIS Experience"
+            height={400}
+            style={{ gridColumn: "span 2" }}
+          >
+            <div style={{ height: 340 }}>
+              <iframe
                 title="Transport rowerowy"
-                subtitle="Źródło: ArcGIS Experience"
-                height={380}
-              >
-                <div style={{ height: 320 }}>
-                  <iframe
-                    title="Transport rowerowy"
-                    src="https://experience.arcgis.com/experience/673ecf1542034ebeab47c6e7fa6a781b/"
-                    style={{ width: "100%", height: "100%", border: 0 }}
-                    loading="lazy"
-                    allowFullScreen
+                src="https://experience.arcgis.com/experience/673ecf1542034ebeab47c6e7fa6a781b/"
+                style={{ width: "100%", height: "100%", border: 0 }}
+                loading="lazy"
+                allowFullScreen
+              />
+            </div>
+          </Card>
+
+          <Card
+            title="Miejsca P&R"
+            subtitle="Źródło: Opracowanie własne"
+            height={380}
+            onOpen={() => setOpenCard("miejsca")}
+          >
+            <div style={{ height: 320 }}>
+              <ResponsiveContainer width="100%" height="100%">
+                <BarChart
+                  data={[
+                    { kategoria: "P+R Górka Narodowa", miejsca: 465.0 },
+                    { kategoria: "P+R Swoszowice", miejsca: 154.0 },
+                    { kategoria: "P+R Krowodrza", miejsca: 109.0 },
+                    { kategoria: "Łuczyce", miejsca: 106.0 },
+                    { kategoria: "P+R Pachońskiego", miejsca: 95.0 },
+                    { kategoria: "P+R Prądnik Czerwony", miejsca: 83.0 },
+                    { kategoria: "Kocmyrzów", miejsca: 72.0 },
+                    { kategoria: "Baranówka", miejsca: 53.0 },
+                    { kategoria: "Zastów", miejsca: 51.0 },
+                    { kategoria: "Goszcza", miejsca: 47.0 },
+                  ]
+                    .slice()
+                    .sort((a, b) => b.miejsca - a.miejsca)}
+                  margin={{ top: 8, right: 8, bottom: 84, left: 8 }}
+                >
+                  <CartesianGrid vertical={false} stroke="#eee" />
+                  <XAxis
+                    dataKey="kategoria"
+                    angle={-45}
+                    textAnchor="end"
+                    interval={0}
+                    height={60}
+                    tick={{ fontSize: 11 }}
                   />
-                </div>
-              </Card>
+                  <YAxis tick={{ fontSize: 11 }} />
+                  <Tooltip
+                    formatter={(v: number) => [String(v), "miejsca P&R"]}
+                    labelStyle={{ fontSize: 11 }}
+                    itemStyle={{ fontSize: 11 }}
+                  />
+                  <Bar
+                    dataKey="miejsca"
+                    name="Liczba miejsc P&R"
+                    fill="rgb(54, 169, 225)"
+                  />
+                </BarChart>
+              </ResponsiveContainer>
             </div>
-
-            <div style={{ breakInside: "avoid", marginBottom: 12 }}>
-              <Card
-                title="Czynniki wyboru środka transportu"
-                subtitle="Źródło: Raport z badań społecznych 2024"
-                height={340}
-                onOpen={() => setOpenCard("czynniki")}
-              >
-                <div style={{ height: 280 }}>
-                  <ResponsiveContainer width="100%" height="100%">
-                    <BarChart
-                      data={[
-                        { czynnik: "Komfort podróży", odsetek: 59 },
-                        {
-                          czynnik: "Brak alternatywy",
-                          odsetek: 15,
-                        },
-                        { czynnik: "Czas przejazdu", odsetek: 13 },
-                        { czynnik: "Koszty", odsetek: 5 },
-                        { czynnik: "Bezpieczeństwo", odsetek: 4 },
-                        { czynnik: "Inne", odsetek: 3 },
-                        { czynnik: "Środowisko", odsetek: 1 },
-                      ]}
-                      margin={{ top: 8, right: 8, bottom: 16, left: 8 }}
-                    >
-                      <CartesianGrid vertical={false} stroke="#eee" />
-                      <XAxis
-                        dataKey="czynnik"
-                        interval={0}
-                        angle={-15}
-                        textAnchor="end"
-                        height={60}
-                        tick={{ fontSize: 11 }}
-                      />
-                      <YAxis unit="%" tick={{ fontSize: 11 }} />
-                      <Tooltip
-                        formatter={(v: number) => [`${v}%`, "odsetek"]}
-                        labelStyle={{ fontSize: 11 }}
-                        itemStyle={{ fontSize: 11 }}
-                      />
-                      <Bar
-                        dataKey="odsetek"
-                        name="Udział odpowiedzi [%]"
-                        fill="rgb(29, 113, 184)"
-                      />
-                    </BarChart>
-                  </ResponsiveContainer>
-                </div>
-              </Card>
-            </div>
-
-            <div style={{ breakInside: "avoid", marginBottom: 12 }}>
-              <Card
-                title="Podział modalny podróży"
-                subtitle="Źródło: Raport z badań społecznych 2024"
-                height={340}
-                onOpen={() => setOpenCard("podzial")}
-              >
-                <div style={{ height: 280 }}>
-                  <ResponsiveContainer width="100%" height="100%">
-                    <BarChart
-                      data={[
-                        { srodek: "Samochód", udzial: 63 },
-                        { srodek: "Komunikacja", udzial: 22 },
-                        { srodek: "Pieszo", udzial: 10 },
-                        { srodek: "Rower", udzial: 3 },
-                        { srodek: "Pociąg", udzial: 0.8 },
-                        { srodek: "Hulajnoga", udzial: 0.4 },
-                      ]}
-                      margin={{ top: 8, right: 8, bottom: 16, left: 8 }}
-                    >
-                      <CartesianGrid vertical={false} stroke="#eee" />
-                      <XAxis
-                        dataKey="srodek"
-                        interval={0}
-                        angle={-15}
-                        textAnchor="end"
-                        height={60}
-                        tick={{ fontSize: 11 }}
-                      />
-                      <YAxis unit="%" tick={{ fontSize: 11 }} />
-                      <Tooltip
-                        formatter={(v: number) => [
-                          `${Number(v).toFixed(v < 1 ? 1 : 0)}%`,
-                          "udział",
-                        ]}
-                        labelStyle={{ fontSize: 11 }}
-                        itemStyle={{ fontSize: 11 }}
-                      />
-                      <Bar
-                        dataKey="udzial"
-                        name="Udział podróży [%]"
-                        fill="rgb(54, 169, 225)"
-                      />
-                    </BarChart>
-                  </ResponsiveContainer>
-                </div>
-              </Card>
-            </div>
-
-            <div style={{ breakInside: "avoid", marginBottom: 12 }}>
-              <Card
-                title="Stacje kolejowe"
-                subtitle="Źródło: Opracowanie własne"
-                height={340}
-                onOpen={() => setOpenCard("stacje")}
-              >
-                <div style={{ height: 280 }}>
-                  <ResponsiveContainer width="100%" height="100%">
-                    <BarChart
-                      data={[
-                        { kategoria: "Kocmyrzów-Luborzyca", liczba: 4.0 },
-                        { kategoria: "Kraków (miejskie)", liczba: 31.0 },
-                      ]}
-                      margin={{ top: 8, right: 8, bottom: 16, left: 8 }}
-                    >
-                      <CartesianGrid vertical={false} stroke="#eee" />
-                      <XAxis dataKey="kategoria" tick={{ fontSize: 11 }} />
-                      <YAxis tick={{ fontSize: 11 }} />
-                      <Tooltip
-                        formatter={(v: number) => [String(v), "liczba"]}
-                        labelStyle={{ fontSize: 11 }}
-                        itemStyle={{ fontSize: 11 }}
-                      />
-                      <Bar
-                        dataKey="liczba"
-                        name="Liczba stacji/przystanków"
-                        fill="rgb(29, 113, 184)"
-                      />
-                    </BarChart>
-                  </ResponsiveContainer>
-                </div>
-              </Card>
-            </div>
-
-            <div style={{ breakInside: "avoid", marginBottom: 12 }}>
-              <Card
-                title="Miejsca P&R"
-                subtitle="Źródło: Opracowanie własne"
-                height={380}
-                onOpen={() => setOpenCard("miejsca")}
-              >
-                <div style={{ height: 320 }}>
-                  <ResponsiveContainer width="100%" height="100%">
-                    <BarChart
-                      data={[
-                        { kategoria: "P+R Górka Narodowa", miejsca: 465.0 },
-                        { kategoria: "P+R Swoszowice", miejsca: 154.0 },
-                        { kategoria: "P+R Krowodrza", miejsca: 109.0 },
-                        { kategoria: "Łuczyce", miejsca: 106.0 },
-                        { kategoria: "P+R Pachońskiego", miejsca: 95.0 },
-                        { kategoria: "P+R Prądnik Czerwony", miejsca: 83.0 },
-                        { kategoria: "Kocmyrzów", miejsca: 72.0 },
-                        { kategoria: "Baranówka", miejsca: 53.0 },
-                        { kategoria: "Zastów", miejsca: 51.0 },
-                        { kategoria: "Goszcza", miejsca: 47.0 },
-                      ]
-                        .slice()
-                        .sort((a, b) => b.miejsca - a.miejsca)}
-                      margin={{ top: 8, right: 8, bottom: 84, left: 8 }}
-                    >
-                      <CartesianGrid vertical={false} stroke="#eee" />
-                      <XAxis
-                        dataKey="kategoria"
-                        angle={-45}
-                        textAnchor="end"
-                        interval={0}
-                        height={60}
-                        tick={{ fontSize: 11 }}
-                      />
-                      <YAxis tick={{ fontSize: 11 }} />
-                      <Tooltip
-                        formatter={(v: number) => [String(v), "miejsca P&R"]}
-                        labelStyle={{ fontSize: 11 }}
-                        itemStyle={{ fontSize: 11 }}
-                      />
-                      <Bar
-                        dataKey="miejsca"
-                        name="Liczba miejsc P&R"
-                        fill="rgb(54, 169, 225)"
-                      />
-                    </BarChart>
-                  </ResponsiveContainer>
-                </div>
-              </Card>
+          </Card>
             </div>
           </div>
         </div>
@@ -415,36 +366,6 @@ export default function Mobilnosc() {
                 dataKey="udzial"
                 name="Udział podróży [%]"
                 fill="rgb(54, 169, 225)"
-              />
-            </BarChart>
-          </ResponsiveContainer>
-        </div>
-      </Modal>
-
-      <Modal
-        open={openCard === "stacje"}
-        onClose={() => setOpenCard(null)}
-        title="Stacje kolejowe"
-        width={1100}
-        maxWidth="95vw"
-      >
-        <div style={{ height: 600 }}>
-          <ResponsiveContainer width="100%" height="100%">
-            <BarChart
-              data={[
-                { kategoria: "Kocmyrzów-Luborzyca", liczba: 4.0 },
-                { kategoria: "Kraków (miejskie)", liczba: 31.0 },
-              ]}
-              margin={{ top: 8, right: 8, bottom: 16, left: 8 }}
-            >
-              <CartesianGrid vertical={false} stroke="#eee" />
-              <XAxis dataKey="kategoria" />
-              <YAxis />
-              <Tooltip formatter={(v: number) => [String(v), "liczba"]} />
-              <Bar
-                dataKey="liczba"
-                name="Liczba stacji/przystanków"
-                fill="rgb(29, 113, 184)"
               />
             </BarChart>
           </ResponsiveContainer>

--- a/mk-dashboard/src/pages/SrodowiskoPrzestrzen.tsx
+++ b/mk-dashboard/src/pages/SrodowiskoPrzestrzen.tsx
@@ -12,8 +12,8 @@ import {
 } from "recharts";
 
 export default function SrodowiskoPrzestrzen() {
-  const [scale, setScale] = useState(1);
   const [openCard, setOpenCard] = useState<string | null>(null);
+  const [scale, setScale] = useState(1);
 
   return (
     <div
@@ -42,34 +42,29 @@ export default function SrodowiskoPrzestrzen() {
             overflow: "hidden",
             display: "flex",
             justifyContent: "center",
-            alignItems: "flex-start",
+            padding: "0 32px",
           }}
         >
           <div
             style={{
-              columnCount: 3,
-              columnGap: 12,
               transformOrigin: "top center",
               transform: `scale(${scale})`,
               width: "100%",
+              maxWidth: "1800px",
             }}
             ref={(el) => {
               if (el && el.parentElement?.parentElement) {
                 const container = el.parentElement.parentElement;
                 const updateScale = () => {
                   const containerHeight = container.clientHeight;
-                  const containerWidth = container.clientWidth;
 
                   el.style.transform = "scale(1)";
                   const contentHeight = el.scrollHeight;
-                  const contentWidth = el.scrollWidth;
                   el.style.transform = `scale(${scale})`;
 
                   const heightScale = containerHeight / contentHeight;
-                  const widthScale = containerWidth / contentWidth;
-
-                  let newScale = Math.min(heightScale, widthScale, 1);
-                  newScale = Math.max(0.5, Math.min(1, newScale));
+                  let newScale = Math.min(heightScale, 1);
+                  newScale = Math.max(0.4, Math.min(1, newScale));
 
                   setScale(newScale);
                 };
@@ -86,280 +81,278 @@ export default function SrodowiskoPrzestrzen() {
               }
             }}
           >
-            <div style={{ breakInside: "avoid", marginBottom: 12 }}>
-              <Card
-                title="Odpady komunalne na mieszkańca"
-                subtitle="Źródło: ArcGIS Experience"
-                height={380}
-                onOpen={() => setOpenCard("odpady")}
-              >
-                <div style={{ height: 320 }}>
-                  <iframe
-                    title="Ilość odebranych odpadów komunalnych"
-                    src="https://experience.arcgis.com/experience/7d0ef674f28046cc96aeb83fa7a89b0c/"
-                    style={{ width: "100%", height: "100%", border: 0 }}
-                    loading="lazy"
-                    allowFullScreen
-                  />
-                </div>
-              </Card>
-            </div>
+            <div
+              style={{
+                display: "grid",
+                gridTemplateColumns: "repeat(3, 1fr)",
+                gap: 12,
+              }}
+            >
+            <Card
+              title="Odpady komunalne na mieszkańca"
+              subtitle="Źródło: ArcGIS Experience"
+              height={420}
+              onOpen={() => setOpenCard("odpady")}
+              style={{ gridColumn: "span 2" }}
+            >
+              <div style={{ height: 340 }}>
+                <iframe
+                  title="Ilość odebranych odpadów komunalnych"
+                  src="https://experience.arcgis.com/experience/7d0ef674f28046cc96aeb83fa7a89b0c/"
+                  style={{ width: "100%", height: "100%", border: 0 }}
+                  loading="lazy"
+                  allowFullScreen
+                />
+              </div>
+            </Card>
 
-            <div style={{ breakInside: "avoid", marginBottom: 12 }}>
-              <Card
-                title="Redukcja emisji pyłu PM2,5"
-                subtitle="Źródło: ArcGIS Experience"
-                height={380}
-                onOpen={() => setOpenCard("pm25")}
-              >
-                <div style={{ height: 320 }}>
-                  <iframe
-                    title="Redukcja emisji pyłu PM2,5"
-                    src="https://experience.arcgis.com/experience/2cd7bc91e15148b59c6f5342b24e7f00/"
-                    style={{ width: "100%", height: "100%", border: 0 }}
-                    loading="lazy"
-                    allowFullScreen
-                  />
-                </div>
-              </Card>
-            </div>
+            <Card
+              title="Poziom recyklingu odpadów"
+              subtitle="Źródło: BDL GUS"
+              height={420}
+              onOpen={() => setOpenCard("recykling")}
+            >
+              <div style={{ height: 360 }}>
+                <ResponsiveContainer width="100%" height="100%">
+                  <BarChart
+                    data={[
+                      { gmina: "Igołomia-Wawrzeńczyce", poziom: 67.52 },
+                      { gmina: "Liszki", poziom: 66.14 },
+                      { gmina: "Wielka Wieś", poziom: 56.9 },
+                      { gmina: "Czernichów", poziom: 52.96 },
+                      { gmina: "Zabierzów", poziom: 52.86 },
+                      { gmina: "Zielonki", poziom: 52.17 },
+                      { gmina: "Kraków", poziom: 52.33 },
+                      { gmina: "Skawina", poziom: 51.35 },
+                      { gmina: "Mogilany", poziom: 48.21 },
+                      { gmina: "Michałowice", poziom: 49.06 },
+                      { gmina: "Niepołomice", poziom: 46.27 },
+                      { gmina: "Kocmyrzów-Luborzyca", poziom: 46.31 },
+                      { gmina: "Biskupice", poziom: 45.77 },
+                      { gmina: "Świątniki Górne", poziom: 45.84 },
+                      { gmina: "Wieliczka", poziom: 25 },
+                    ]
+                      .slice()
+                      .sort((a, b) => b.poziom - a.poziom)}
+                    margin={{ top: 8, right: 8, bottom: 100, left: 8 }}
+                  >
+                    <CartesianGrid vertical={false} stroke="#eee" />
+                    <XAxis
+                      dataKey="gmina"
+                      angle={-60}
+                      textAnchor="end"
+                      interval={0}
+                      height={60}
+                      tick={{ fontSize: 11 }}
+                    />
+                    <YAxis unit="%" tick={{ fontSize: 11 }} />
+                    <Tooltip
+                      formatter={(v: number) => [`${v}%`, "poziom"]}
+                      labelStyle={{ fontSize: 11 }}
+                      itemStyle={{ fontSize: 11 }}
+                    />
+                    <Bar
+                      dataKey="poziom"
+                      name="Poziom recyklingu [%]"
+                      fill="rgb(149, 193, 31)"
+                    />
+                  </BarChart>
+                </ResponsiveContainer>
+              </div>
+            </Card>
 
-            <div style={{ breakInside: "avoid", marginBottom: 12 }}>
-              <Card
-                title="Poziom recyklingu odpadów"
-                subtitle="Źródło: BDL GUS"
-                height={380}
-                onOpen={() => setOpenCard("recykling")}
-              >
-                <div style={{ height: 320 }}>
-                  <ResponsiveContainer width="100%" height="100%">
-                    <BarChart
-                      data={[
-                        { gmina: "Igołomia-Wawrzeńczyce", poziom: 67.52 },
-                        { gmina: "Liszki", poziom: 66.14 },
-                        { gmina: "Wielka Wieś", poziom: 56.9 },
-                        { gmina: "Czernichów", poziom: 52.96 },
-                        { gmina: "Zabierzów", poziom: 52.86 },
-                        { gmina: "Zielonki", poziom: 52.17 },
-                        { gmina: "Kraków", poziom: 52.33 },
-                        { gmina: "Skawina", poziom: 51.35 },
-                        { gmina: "Mogilany", poziom: 48.21 },
-                        { gmina: "Michałowice", poziom: 49.06 },
-                        { gmina: "Niepołomice", poziom: 46.27 },
-                        { gmina: "Kocmyrzów-Luborzyca", poziom: 46.31 },
-                        { gmina: "Biskupice", poziom: 45.77 },
-                        { gmina: "Świątniki Górne", poziom: 45.84 },
-                        { gmina: "Wieliczka", poziom: 25 },
-                      ]
-                        .slice()
-                        .sort((a, b) => b.poziom - a.poziom)}
-                      margin={{ top: 8, right: 8, bottom: 84, left: 8 }}
-                    >
-                      <CartesianGrid vertical={false} stroke="#eee" />
-                      <XAxis
-                        dataKey="gmina"
-                        angle={-60}
-                        textAnchor="end"
-                        interval={0}
-                        height={60}
-                        tick={{ fontSize: 11 }}
-                      />
-                      <YAxis unit="%" tick={{ fontSize: 11 }} />
-                      <Tooltip
-                        formatter={(v: number) => [`${v}%`, "poziom"]}
-                        labelStyle={{ fontSize: 11 }}
-                        itemStyle={{ fontSize: 11 }}
-                      />
-                      <Bar
-                        dataKey="poziom"
-                        name="Poziom recyklingu [%]"
-                        fill="rgb(149, 193, 31)"
-                      />
-                    </BarChart>
-                  </ResponsiveContainer>
-                </div>
-              </Card>
-            </div>
+            <Card
+              title="Redukcja emisji pyłu PM2,5"
+              subtitle="Źródło: ArcGIS Experience"
+              height={300}
+              onOpen={() => setOpenCard("pm25")}
+              style={{ gridColumn: "span 2" }}
+            >
+              <div style={{ height: 240 }}>
+                <iframe
+                  title="Redukcja emisji pyłu PM2,5"
+                  src="https://experience.arcgis.com/experience/2cd7bc91e15148b59c6f5342b24e7f00/"
+                  style={{ width: "100%", height: "100%", border: 0 }}
+                  loading="lazy"
+                  allowFullScreen
+                />
+              </div>
+            </Card>
 
-            <div style={{ breakInside: "avoid", marginBottom: 12 }}>
-              <Card
-                title="Redukcja emisji pyłu PM10"
-                subtitle="Źródło: Program ochrony powietrza"
-                height={380}
-                onOpen={() => setOpenCard("pm10")}
-              >
-                <div style={{ height: 320 }}>
-                  <ResponsiveContainer width="100%" height="100%">
-                    <BarChart
-                      data={[
-                        { gmina: "Czernichów", pm10: 11.07 },
-                        { gmina: "Igołomia-Wawrzeńczyce", pm10: 1.89 },
-                        { gmina: "Kocmyrzów-Luborzyca", pm10: 3.07 },
-                        { gmina: "Liszki", pm10: 2.94 },
-                        { gmina: "Michałowice", pm10: 4.57 },
-                        { gmina: "Mogilany", pm10: 1.34 },
-                        { gmina: "Skawina", pm10: 2.45 },
-                        { gmina: "Świątniki Górne", pm10: 3.45 },
-                        { gmina: "Wielka Wieś", pm10: 3.2 },
-                        { gmina: "Zabierzów", pm10: 5.49 },
-                        { gmina: "Zielonki", pm10: 3.23 },
-                        { gmina: "Biskupice", pm10: 4.14 },
-                        { gmina: "Niepołomice", pm10: 3.52 },
-                        { gmina: "Wieliczka", pm10: 12.87 },
-                        { gmina: "Kraków", pm10: 2.07 },
-                      ]
-                        .slice()
-                        .sort((a, b) => b.pm10 - a.pm10)}
-                      margin={{ top: 8, right: 8, bottom: 84, left: 8 }}
-                    >
-                      <CartesianGrid vertical={false} stroke="#eee" />
-                      <XAxis
-                        dataKey="gmina"
-                        angle={-35}
-                        textAnchor="end"
-                        interval={0}
-                        height={60}
-                        tick={{ fontSize: 11 }}
-                      />
-                      <YAxis unit=" Mg" tick={{ fontSize: 11 }} />
-                      <Tooltip
-                        formatter={(v: number) => [
-                          v.toString(),
-                          "redukcja PM10",
-                        ]}
-                        labelStyle={{ fontSize: 11 }}
-                        itemStyle={{ fontSize: 11 }}
-                      />
-                      <Bar
-                        dataKey="pm10"
-                        name="Redukcja PM10 [Mg]"
-                        fill="rgb(58, 142, 20)"
-                      />
-                    </BarChart>
-                  </ResponsiveContainer>
-                </div>
-              </Card>
-            </div>
+            <Card
+              title="Redukcja emisji pyłu PM10"
+              subtitle="Źródło: Program ochrony powietrza"
+              height={300}
+              onOpen={() => setOpenCard("pm10")}
+            >
+              <div style={{ height: 240 }}>
+                <ResponsiveContainer width="100%" height="100%">
+                  <BarChart
+                    data={[
+                      { gmina: "Czernichów", pm10: 11.07 },
+                      { gmina: "Igołomia-Wawrzeńczyce", pm10: 1.89 },
+                      { gmina: "Kocmyrzów-Luborzyca", pm10: 3.07 },
+                      { gmina: "Liszki", pm10: 2.94 },
+                      { gmina: "Michałowice", pm10: 4.57 },
+                      { gmina: "Mogilany", pm10: 1.34 },
+                      { gmina: "Skawina", pm10: 2.45 },
+                      { gmina: "Świątniki Górne", pm10: 3.45 },
+                      { gmina: "Wielka Wieś", pm10: 3.2 },
+                      { gmina: "Zabierzów", pm10: 5.49 },
+                      { gmina: "Zielonki", pm10: 3.23 },
+                      { gmina: "Biskupice", pm10: 4.14 },
+                      { gmina: "Niepołomice", pm10: 3.52 },
+                      { gmina: "Wieliczka", pm10: 12.87 },
+                      { gmina: "Kraków", pm10: 2.07 },
+                    ]
+                      .slice()
+                      .sort((a, b) => b.pm10 - a.pm10)}
+                    margin={{ top: 8, right: 8, bottom: 84, left: 8 }}
+                  >
+                    <CartesianGrid vertical={false} stroke="#eee" />
+                    <XAxis
+                      dataKey="gmina"
+                      angle={-35}
+                      textAnchor="end"
+                      interval={0}
+                      height={60}
+                      tick={{ fontSize: 11 }}
+                    />
+                    <YAxis unit=" Mg" tick={{ fontSize: 11 }} />
+                    <Tooltip
+                      formatter={(v: number) => [
+                        v.toString(),
+                        "redukcja PM10",
+                      ]}
+                      labelStyle={{ fontSize: 11 }}
+                      itemStyle={{ fontSize: 11 }}
+                    />
+                    <Bar
+                      dataKey="pm10"
+                      name="Redukcja PM10 [Mg]"
+                      fill="rgb(58, 142, 20)"
+                    />
+                  </BarChart>
+                </ResponsiveContainer>
+              </div>
+            </Card>
 
-            <div style={{ breakInside: "avoid", marginBottom: 12 }}>
-              <Card
-                title="Mieszkania oddane do użytkowania"
-                subtitle="Źródło: BDL GUS"
-                height={380}
-                onOpen={() => setOpenCard("mieszkania")}
-              >
-                <div style={{ height: 320 }}>
-                  <ResponsiveContainer width="100%" height="100%">
-                    <BarChart
-                      data={[
-                        { gmina: "Wieliczka", wartosc: 118.4 },
-                        { gmina: "Kraków", wartosc: 107.1 },
-                        { gmina: "Biskupice", wartosc: 93.7 },
-                        { gmina: "Niepołomice", wartosc: 84 },
-                        { gmina: "Kocmyrzów-Luborzyca", wartosc: 75.6 },
-                        { gmina: "Wielka Wieś", wartosc: 54.7 },
-                        { gmina: "Zabierzów", wartosc: 57.2 },
-                        { gmina: "Czernichów", wartosc: 51.8 },
-                        { gmina: "Michałowice", wartosc: 48.9 },
-                        { gmina: "Świątniki Górne", wartosc: 47.4 },
-                        { gmina: "Niepołomice", wartosc: 84 },
-                        { gmina: "Zielonki", wartosc: 43.6 },
-                        { gmina: "Mogilany", wartosc: 41.4 },
-                        { gmina: "Liszki", wartosc: 37.5 },
-                        { gmina: "Skawina", wartosc: 26.4 },
-                        { gmina: "Igołomia-Wawrzeńczyce", wartosc: 20.4 },
-                      ]
-                        .filter(
-                          (v, i, arr) =>
-                            arr.findIndex((x) => x.gmina === v.gmina) === i
-                        )
-                        .slice()
-                        .sort((a, b) => b.wartosc - a.wartosc)}
-                      margin={{ top: 8, right: 8, bottom: 84, left: 8 }}
-                    >
-                      <CartesianGrid vertical={false} stroke="#eee" />
-                      <XAxis
-                        dataKey="gmina"
-                        angle={-35}
-                        textAnchor="end"
-                        interval={0}
-                        height={60}
-                        tick={{ fontSize: 11 }}
-                      />
-                      <YAxis tick={{ fontSize: 11 }} />
-                      <Tooltip
-                        formatter={(v: number) => [
-                          v.toString(),
-                          "na 10 tys. ludności",
-                        ]}
-                        labelStyle={{ fontSize: 11 }}
-                        itemStyle={{ fontSize: 11 }}
-                      />
-                      <Bar
-                        dataKey="wartosc"
-                        name="Mieszkania na 10 tys. mieszkańców"
-                        fill="rgb(149, 193, 31)"
-                      />
-                    </BarChart>
-                  </ResponsiveContainer>
-                </div>
-              </Card>
-            </div>
+            <Card
+              title="Mieszkania oddane do użytkowania"
+              subtitle="Źródło: BDL GUS"
+              height={300}
+              onOpen={() => setOpenCard("mieszkania")}
+            >
+              <div style={{ height: 240 }}>
+                <ResponsiveContainer width="100%" height="100%">
+                  <BarChart
+                    data={[
+                      { gmina: "Wieliczka", wartosc: 118.4 },
+                      { gmina: "Kraków", wartosc: 107.1 },
+                      { gmina: "Biskupice", wartosc: 93.7 },
+                      { gmina: "Niepołomice", wartosc: 84 },
+                      { gmina: "Kocmyrzów-Luborzyca", wartosc: 75.6 },
+                      { gmina: "Wielka Wieś", wartosc: 54.7 },
+                      { gmina: "Zabierzów", wartosc: 57.2 },
+                      { gmina: "Czernichów", wartosc: 51.8 },
+                      { gmina: "Michałowice", wartosc: 48.9 },
+                      { gmina: "Świątniki Górne", wartosc: 47.4 },
+                      { gmina: "Niepołomice", wartosc: 84 },
+                      { gmina: "Zielonki", wartosc: 43.6 },
+                      { gmina: "Mogilany", wartosc: 41.4 },
+                      { gmina: "Liszki", wartosc: 37.5 },
+                      { gmina: "Skawina", wartosc: 26.4 },
+                      { gmina: "Igołomia-Wawrzeńczyce", wartosc: 20.4 },
+                    ]
+                      .filter(
+                        (v, i, arr) =>
+                          arr.findIndex((x) => x.gmina === v.gmina) === i
+                      )
+                      .slice()
+                      .sort((a, b) => b.wartosc - a.wartosc)}
+                    margin={{ top: 8, right: 8, bottom: 84, left: 8 }}
+                  >
+                    <CartesianGrid vertical={false} stroke="#eee" />
+                    <XAxis
+                      dataKey="gmina"
+                      angle={-35}
+                      textAnchor="end"
+                      interval={0}
+                      height={60}
+                      tick={{ fontSize: 11 }}
+                    />
+                    <YAxis tick={{ fontSize: 11 }} />
+                    <Tooltip
+                      formatter={(v: number) => [
+                        v.toString(),
+                        "na 10 tys. ludności",
+                      ]}
+                      labelStyle={{ fontSize: 11 }}
+                      itemStyle={{ fontSize: 11 }}
+                    />
+                    <Bar
+                      dataKey="wartosc"
+                      name="Mieszkania na 10 tys. mieszkańców"
+                      fill="rgb(149, 193, 31)"
+                    />
+                  </BarChart>
+                </ResponsiveContainer>
+              </div>
+            </Card>
 
-            <div style={{ breakInside: "avoid", marginBottom: 12 }}>
-              <Card
-                title="Udział energii z OZE"
-                subtitle="Źródło: Opracowanie własne"
-                height={380}
-                onOpen={() => setOpenCard("oze")}
-              >
-                <div style={{ height: 320 }}>
-                  <ResponsiveContainer width="100%" height="100%">
-                    <BarChart
-                      data={[
-                        { gmina: "Czernichów", oze: 100.0 },
-                        { gmina: "Biskupice", oze: 26.4 },
-                        { gmina: "Mogilany", oze: 10.0 },
-                        { gmina: "Igołomia-Wawrzeńczyce", oze: 5.0 },
-                        { gmina: "Kraków", oze: 4.83 },
-                      ]
-                        .slice()
-                        .sort((a, b) => b.oze - a.oze)}
-                      margin={{ top: 8, right: 8, bottom: 84, left: 8 }}
-                    >
-                      <CartesianGrid vertical={false} stroke="#eee" />
-                      <XAxis
-                        dataKey="gmina"
-                        angle={-35}
-                        textAnchor="end"
-                        interval={0}
-                        height={60}
-                        tick={{ fontSize: 11 }}
-                      />
-                      <YAxis unit="%" tick={{ fontSize: 11 }} />
-                      <Tooltip
-                        formatter={(v: number) => [
-                          `${(v as number).toFixed(2)}%`,
-                          "udział OZE",
-                        ]}
-                        labelStyle={{ fontSize: 11 }}
-                        itemStyle={{ fontSize: 11 }}
-                      />
-                      <Bar
-                        dataKey="oze"
-                        name="Udział energii z OZE [%]"
-                        fill="rgb(58, 142, 20)"
-                      />
-                    </BarChart>
-                  </ResponsiveContainer>
-                </div>
-              </Card>
+            <Card
+              title="Udział energii z OZE"
+              subtitle="Źródło: Opracowanie własne"
+              height={300}
+              onOpen={() => setOpenCard("oze")}
+            >
+              <div style={{ height: 240 }}>
+                <ResponsiveContainer width="100%" height="100%">
+                  <BarChart
+                    data={[
+                      { gmina: "Czernichów", oze: 100.0 },
+                      { gmina: "Biskupice", oze: 26.4 },
+                      { gmina: "Mogilany", oze: 10.0 },
+                      { gmina: "Igołomia-Wawrzeńczyce", oze: 5.0 },
+                      { gmina: "Kraków", oze: 4.83 },
+                    ]
+                      .slice()
+                      .sort((a, b) => b.oze - a.oze)}
+                    margin={{ top: 8, right: 8, bottom: 84, left: 8 }}
+                  >
+                    <CartesianGrid vertical={false} stroke="#eee" />
+                    <XAxis
+                      dataKey="gmina"
+                      angle={-35}
+                      textAnchor="end"
+                      interval={0}
+                      height={60}
+                      tick={{ fontSize: 11 }}
+                    />
+                    <YAxis unit="%" tick={{ fontSize: 11 }} />
+                    <Tooltip
+                      formatter={(v: number) => [
+                        `${(v as number).toFixed(2)}%`,
+                        "udział OZE",
+                      ]}
+                      labelStyle={{ fontSize: 11 }}
+                      itemStyle={{ fontSize: 11 }}
+                    />
+                    <Bar
+                      dataKey="oze"
+                      name="Udział energii z OZE [%]"
+                      fill="rgb(58, 142, 20)"
+                    />
+                  </BarChart>
+                </ResponsiveContainer>
+              </div>
+            </Card>
             </div>
           </div>
         </div>
       </div>
 
-      {/* Modals */}
+      {/* Modals - keeping existing modal implementations */}
       <Modal
         open={openCard === "odpady"}
         onClose={() => setOpenCard(null)}


### PR DESCRIPTION
  - Add auto-scaling pattern with transform scale and ResizeObserver to all pages
  - Replace column-based layouts with CSS Grid for better space utilization
  - Reorganize InformacjeOgolne page with flex containers for compact layout
  - Move "Czytelnicy w bibliotekach" chart to first row in KulturaCzasuWolnego
  - Remove scroll overflow to enable fullscreen TV presentation without mouse interaction
  - Add optional style prop to Card component for grid spanning
  - Add CLAUDE.md project documentation